### PR TITLE
Fix slack-web parse bugs for shared channels

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
     "slack-web": {
       "flake": false,
       "locked": {
-        "lastModified": 1665702777,
-        "narHash": "sha256-TfIi6gHBWhJNuYjMo3Pi3p9o0a0S+ZwZx/36yXf3y24=",
+        "lastModified": 1667584293,
+        "narHash": "sha256-0vOHJhE/8Ct+FOcEZK165qmdCv1M8KhjKDSLD4LAFj8=",
         "owner": "mercurytechnologies",
         "repo": "slack-web",
-        "rev": "7fd47a2ed6e69ceb0329df2b5ad7f47c38dfe376",
+        "rev": "f567c8ec5e036f1cd7890de8d71e747416ff7b20",
         "type": "github"
       },
       "original": {

--- a/src/Slacklinker/Sender.hs
+++ b/src/Slacklinker/Sender.hs
@@ -126,8 +126,14 @@ fetchAllConversations wsInfo = do
         )
   liftIO $ loadingPage list_ convertPage
   where
+    -- We exclude shared channels from conversations that we care about, mostly
+    -- just to be safe. The bot can be manually joined to such channels if so
+    -- desired.
+    isShared (Channel c) = channelIsShared c
+    isShared _ = False
+
     convertPage resp =
-      fromList @(Vector _) <$> fromEither resp
+      fromList @(Vector _) . filter (not . isShared) <$> fromEither resp
 
 doJoinAll :: (HasApp m, MonadIO m) => WorkspaceMeta -> ConversationId -> m ()
 doJoinAll wsInfo cid = do


### PR DESCRIPTION
There was a bug in slack-web that made us unable to parse the response from Slack for channels listing, found on the Mercury workspace. This PR adopts that upstream fix.