### PR TITLE
Switch to upstream slack-web

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,25 +51,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "slack-web": "slack-web"
-      }
-    },
-    "slack-web": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1671047347,
-        "narHash": "sha256-s/p/5AeUC7BKzCI+ytCvKCMM65O8TQZRIVKRAX9WzYU=",
-        "owner": "mercurytechnologies",
-        "repo": "slack-web",
-        "rev": "116e3a32079d20bb77d71a549838b2674340c4cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mercurytechnologies",
-        "ref": "jadel/users-list-pagination",
-        "repo": "slack-web",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    slack-web = {
-      url = "github:mercurytechnologies/slack-web/jadel/users-list-pagination";
-      flake = false;
-    };
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -16,7 +12,7 @@
 
   nixConfig.allow-import-from-derivation = true; # cabal2nix uses IFD
 
-  outputs = { self, nixpkgs, flake-utils, slack-web, ... }:
+  outputs = { self, nixpkgs, flake-utils, ... }:
     let
       ghcVer = "ghc924";
       makeHaskellOverlay = overlay: final: prev: {
@@ -97,7 +93,13 @@
           in
           {
             slacklinker = build slacklinker;
-            slack-web = hprev.callCabal2nix "slack-web" slack-web { };
+            slack-web = hprev.callHackageDirect
+              {
+                pkg = "slack-web";
+                ver = "1.6.1.0";
+                sha256 = "sha256-qM7doDWZywcNIdr8gHX8mj75cdEdMjFc4LNdDX+pNeM=";
+              }
+              { };
 
             # someone (me) put too tight lower bounds lol
             hs-opentelemetry-instrumentation-hspec = hlib.doJailbreak hprev.hs-opentelemetry-instrumentation-hspec;

--- a/test/Slacklinker/Handler/WebhookSpec.hs
+++ b/test/Slacklinker/Handler/WebhookSpec.hs
@@ -65,7 +65,7 @@ messageEventWithBlocks ts blocks =
 updateThreadTs :: MessageEvent -> Maybe Text -> MessageEvent
 updateThreadTs MessageEvent {..} newThreadTs = MessageEvent {threadTs = newThreadTs, ..}
 
-doLink :: (HasApp m, MonadIO m) => TeamId -> Text -> Text -> m MessageEvent
+doLink :: (HasApp m, MonadUnliftIO m) => TeamId -> Text -> Text -> m MessageEvent
 doLink teamId ts url = do
   let msg = messageEventWithBlocks ts [SlackBlockRichText . urlRichText $ url]
   handleMessage msg teamId


### PR DESCRIPTION
- slack-web: switch to upstream version 1.6.1.0
- Oh, the testsuite was broken, oops

Fixes ~1100 parse errors in prod honeycomb. Thanks honeycomb for telling us about our bugs.