### PR TITLE
flake: update to ghc 9.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
-        "type": "github"
+        "lastModified": 1714705744,
+        "narHash": "sha256-SsaS620K6QZVCOUqcWU/sHEkipnsJcqslfrU9oko+f4=",
+        "rev": "5adafc5bfbb5b1df965df8ade18b1b0ce00a418e",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/flake-compat/archive/5adafc5bfbb5b1df965df8ade18b1b0ce00a418e.tar.gz"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/flake-compat/archive/main.tar.gz"
       }
     },
     "flake-utils": {
@@ -33,11 +31,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670929434,
-        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
         "type": "github"
       },
       "original": {

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -40,7 +40,7 @@ in
     '';
   })).overrideAttrs (old: {
   # Don’t allow focused tests to pass CI
-  HSPEC_OPTIONS = "--fail-on-focused";
+  HSPEC_OPTIONS = "--fail-on=focused";
 
   disallowedReferences = badReferences;
 

--- a/src/Slacklinker/App.hs
+++ b/src/Slacklinker/App.hs
@@ -18,6 +18,7 @@ import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Logger (LogLevel (..), MonadLoggerIO, ToLogStr (..), defaultOutput)
 import Control.Monad.Logger.CallStack (MonadLoggerIO (..))
 import Data.ByteString.Char8 qualified as BS
+import Data.HashMap.Strict qualified as HM
 import Data.Pool (Pool, destroyAllResources)
 import Database.Persist.Postgresql (SqlBackend, createPostgresqlPool, runSqlPoolWithExtensibleHooks)
 import Database.Persist.SqlBackend.SqlPoolHooks
@@ -40,7 +41,7 @@ data AppConfig = AppConfig
   }
   deriving stock (Show)
 
-appSlackConfig :: HasApp m => SlackToken -> m SlackConfig
+appSlackConfig :: (HasApp m) => SlackToken -> m SlackConfig
 appSlackConfig (SlackToken slackConfigToken) = do
   slackConfigManager <- getsApp (.manager)
   pure SlackConfig {..}
@@ -111,7 +112,7 @@ runDB act = do
   let pool = app.runtimeInfo.appPool
   liftIO $ runSqlPoolWithExtensibleHooks act pool Nothing hooks
   where
-    hooks = setAlterBackend defaultSqlPoolHooks $ OTel.wrapSqlBackend []
+    hooks = setAlterBackend defaultSqlPoolHooks $ OTel.wrapSqlBackend HM.empty
 
 readLogLevel :: [Char] -> LogLevel
 readLogLevel "debug" = LevelDebug

--- a/src/Slacklinker/Models.hs
+++ b/src/Slacklinker/Models.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Slacklinker.Models where
 


### PR DESCRIPTION
Fair warning I have not tested this over and above running the test suite for I do not have a development environment for this.

As requested by @ldub. I spent about 30 minutes looking at this and it wound up being simply easier to just do it than to describe how.