### PR TITLE
Clean up our dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tags
 .envrc
 *.actual
 cabal.project.local
+.direnv/
+result/

--- a/README.md
+++ b/README.md
@@ -154,3 +154,13 @@ files.
 
 Set log level with `LOG_LEVEL=debug` and SQL log level with `LOG_SQL=debug`
 environment variables.
+
+### Updating dependencies
+
+Some Haskell dependencies (such as tmp-postgress and slack-web) are overriden from source in [./nix/deps](https://github.com/MercuryTechnologies/slacklinker/tree/main/nix/deps). To update, use `cabal2nix` (available in your dev shell via nix develop).
+
+```
+cabal2nix "${GITHUB_URI}" > "./nix/deps/${PACKAGE_NAME}.nix"
+```
+
+That command will grab the latest git head from the repo. To get a specific version you can use `--revision`.

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
                               self.refinery-cli
                             ];
                           }
-                          (hsuper.callCabal2nix "slacklinker" ./. { });
+                          hsuper.slacklinker;
 
                       # broken bounds. as mercury people, you can fix this upstream :)
                       slack-web = super.haskell.lib.doJailbreak hsuper.slack-web;
@@ -108,7 +108,10 @@
                     self.lib.fold
                       super.lib.composeExtensions
                       (oldArgs.overrides or (_: _: { }))
-                      [ manualOverrides
+                      [ (self.haskell.lib.packageSourceOverrides {
+                          slacklinker = ./.;
+                        })
+                        manualOverrides
                       ];
               });
             };

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
                 refinery-cli
                 postgresql
                 pgformatter # executable is called pg_format
+                cabal2nix
               ]);
               # Change the prompt to show that you are in a devShell
               # shellHook = "export PS1='\\e[1;34mdev > \\e[0m'";

--- a/flake.nix
+++ b/flake.nix
@@ -105,9 +105,11 @@
                     };
 
                   in
-                    super.lib.composeExtensions
+                    self.lib.fold
+                      super.lib.composeExtensions
                       (oldArgs.overrides or (_: _: { }))
-                      manualOverrides;
+                      [ manualOverrides
+                      ];
               });
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,9 @@
                         slack-web =
                           super.haskell.lib.doJailbreak hsuper.slack-web;
 
+                        tmp-postgres =
+                          super.haskell.lib.dontCheck hsuper.tmp-postgres;
+
                         # possible macOS lack-of-sandbox related breakage
                         http2 =
                           if super.stdenv.isDarwin

--- a/flake.nix
+++ b/flake.nix
@@ -88,16 +88,6 @@
                       # broken bounds. as mercury people, you can fix this upstream :)
                       slack-web = super.haskell.lib.doJailbreak hsuper.slack-web;
 
-                      tmp-postgres = super.haskell.lib.overrideSrc hsuper.tmp-postgres ({
-                        src = self.fetchFromGitHub {
-                          owner = "lambdamechanic";
-                          repo = "tmp-postgres";
-                          # https://github.com/lambdamechanic/tmp-postgres/tree/master
-                          rev = "4c4f4346ea5643d09cee349edac9060fab95a3cb";
-                          sha256 = "sha256-vzfJIrzW7rRpA18rEAHVgQdKuEQ5Aep742MkDShxtj0=";
-                        };
-                      });
-
                       # possible macOS lack-of-sandbox related breakage
                       http2 = if super.stdenv.isDarwin then super.haskell.lib.dontCheck hsuper.http2 else hsuper.http2;
                       # some kinda weird test issues on macOS
@@ -110,6 +100,9 @@
                       (oldArgs.overrides or (_: _: { }))
                       [ (self.haskell.lib.packageSourceOverrides {
                           slacklinker = ./.;
+                        })
+                        (self.haskell.lib.packagesFromDirectory {
+                          directory = ./nix/deps;
                         })
                         manualOverrides
                       ];

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,19 +1,19 @@
-{ prev, final, hfinal, hprev, werror, testToolDepends ? [] }: slacklinker:
+{ super, self, hself, hsuper, werror, testToolDepends ? [] }: slacklinker:
 let
-  hlib = prev.haskell.lib;
-  lib = prev.lib;
+  hlib = super.haskell.lib;
+  lib = super.lib;
   extraFiles = [ ../config ../db ];
   copy = f: "cp -R ${f} $out/${builtins.baseNameOf f}";
   migrateDeps = [
-    final.refinery-cli
+    self.refinery-cli
   ];
 
   # determined through use of `strings | grep /nix/store`
   # allegedly enableSeparateDataOutput does something, but I've not found that
   # to be true. So just nuke it. w/e.
   badReferences = [
-    hfinal.hs-opentelemetry-sdk
-    hfinal.warp
+    hself.hs-opentelemetry-sdk
+    hself.warp
   ];
 
   referencesCmdline = lib.concatMapStrings (x: "-t ${x} ") badReferences;
@@ -45,6 +45,6 @@ in
   disallowedReferences = badReferences;
 
   nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-    final.makeWrapper
+    self.makeWrapper
   ];
 })

--- a/nix/deps/tmp-postgres.nix
+++ b/nix/deps/tmp-postgres.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, async, base, base64-bytestring, bytestring
+, containers, criterion, cryptohash-sha1, deepseq, directory
+, fetchgit, generic-monoid, hspec, lib, mtl, network, port-utils
+, postgres-options, postgresql-simple, prettyprinter, process, stm
+, temporary, transformers, unix
+}:
+mkDerivation {
+  pname = "tmp-postgres";
+  version = "1.35.0.0";
+  src = fetchgit {
+    url = "https://github.com/lambdamechanic/tmp-postgres.git";
+    sha256 = "0gdnf4l0s933wdxyl09r8jw4l1w1sl0i0asz0dlv9vnnphicjdxz";
+    rev = "4c4f4346ea5643d09cee349edac9060fab95a3cb";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    async base base64-bytestring bytestring containers cryptohash-sha1
+    deepseq directory generic-monoid port-utils postgres-options
+    postgresql-simple prettyprinter process stm temporary transformers
+    unix
+  ];
+  executableHaskellDepends = [
+    async base directory postgres-options postgresql-simple process
+    temporary
+  ];
+  testHaskellDepends = [
+    async base containers directory generic-monoid hspec mtl network
+    port-utils postgres-options postgresql-simple process temporary
+    unix
+  ];
+  benchmarkHaskellDepends = [
+    base criterion deepseq postgres-options postgresql-simple temporary
+  ];
+  homepage = "https://github.com/jfischoff/tmp-postgres#readme";
+  description = "Start and stop a temporary postgres";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
The original motivation for these changes is because @ldub was asking what was the easiest way to build slacklinker against a GitHub revision for a dependency (instead of a local checkout or Hackage version).

The simplest answer would have been something like "use `cabal2nix` to generate a Haskell package definition and then manually reference that using `hfinal.callPackage ./thatDependency.nix { }`.  However, I knew that if we were to use `packagesFromDirectory` from Nixpkgs then we could make it easier to do that so that the only thing @ldub would need to do is:

```ShellSession
$ cabal2nix "${GITHUB_URI}" > "./nix/deps/${PACKAGE_NAME}.nix"
```

However, the current `flake.nix` was a little bit disorganized and made it harder to slot in that `packagesFromDirectory` so I refactored it pretty heavily to organize it.

Really, the key change out of all of these commits is 3651c98e3b369f4297b8c8f5df8ee787ccc809b2.  The reset of the changes are refactors paving the way for that (or polishing things up afterwards).

Probably the easiest way to review this is to either review commit-by-commit or to just review the final `flake.nix` and see if that is readable enough for y'all to modify yourselves.