### PR TITLE
monadfail

### DIFF
--- a/src/Slacklinker/App.hs
+++ b/src/Slacklinker/App.hs
@@ -14,6 +14,7 @@ module Slacklinker.App (
   makeApp',
 ) where
 
+import Control.Monad.Fail (MonadFail(..))
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Logger (LogLevel (..), MonadLoggerIO, ToLogStr (..), defaultOutput)
 import Control.Monad.Logger.CallStack (MonadLoggerIO (..))
@@ -105,6 +106,9 @@ instance MonadLoggerIO AppM where
 instance HasApp AppM where
   getApp = do
     AppM ask
+
+instance MonadFail AppM where 
+  fail string = liftIO (fail string)
 
 runAppM :: App -> AppM a -> IO a
 runAppM app act = do

--- a/test/Slacklinker/Handler/WebhookSpec.hs
+++ b/test/Slacklinker/Handler/WebhookSpec.hs
@@ -102,7 +102,7 @@ spec = do
           theLink.threadTs `shouldBe` Nothing
           theLink.sent `shouldBe` False
 
-    it "will not link a message within the same thread" \app -> do
+    fit "will not link a message within the same thread" \app -> do
       runAppM app $ do
         (wsId, teamId) <- createWorkspace
         let (url, parts) = sampleUrl
@@ -114,8 +114,9 @@ spec = do
         handleMessage msg teamId
 
         -- We should not plan a reply to a thread that links to itself
-        ~Nothing <- runDB $ getBy $ UniqueRepliedThread wsId parts.channelId parts.messageTs
-        pure ()
+        res <- runDB $ getBy $ UniqueRepliedThread wsId parts.channelId parts.messageTs
+        putStrLn $ tshow res
+        liftIO $ isNothing res `shouldBe` True
 
     it "will file a link to a message downthread as the same thread as linking the parent" \app -> do
       runAppM app $ do


### PR DESCRIPTION
I'm not sure I understand irrefutable patterns well enough here.

This code change should not result in a test failure, right?

But when running this here's what I see

```
Just (Entity {entityKey = RepliedThreadKey {unRepliedThreadKey = 9893ac80-6b59-11ef-b6ec-1bb88aa6563a}, entityVal = RepliedThread {workspaceId = WorkspaceKey {unWorkspaceKey = 989317ca-6b59-11ef-b6ec-8fbe2162236c}, replyTs = Nothing, conversationId = ConversationId {unConversationId = "C045V0VJT16"}, threadTs = "1665014817.153719"}})
    will not link a message within the same thread [✘]

Failures:

  test/Slacklinker/Handler/WebhookSpec.hs:119:32:
  1) Slacklinker.Handler.Webhook, Should insert RepliedThread for a message, will not link a message within the same thread
       expected: True
        but got: False

  To rerun use: --match "/Slacklinker.Handler.Webhook/Should insert RepliedThread for a message/will not link a message within the same thread/" --seed 97320171

Randomized with seed 97320171

Finished in 0.6849 seconds
1 example, 1 failure
```

So it looks like Slacklinker is actually creating replies in this case, and the tests were just doing nothing? Why didn't the irrefutable pattern trick hide this issue?