### PR TITLE
support for attachments and forwards

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -104,6 +104,7 @@ tests:
       - hspec-expectations
       - hspec-golden >= 0.2
       - slacklinker
+      - string-variants
       - tmp-postgres
 
   test-dev:
@@ -124,6 +125,7 @@ tests:
       - hspec-core
       - hspec-expectations
       - hspec-golden >= 0.2
+      - string-variants
       - tmp-postgres
     when:
       - condition: flag(local-dev)

--- a/src/Slacklinker/Extract/Types.hs
+++ b/src/Slacklinker/Extract/Types.hs
@@ -16,6 +16,7 @@ data ExtractedMessageData = ExtractedMessageData
   , text :: Text
   , blocks :: Maybe [SlackBlock]
   , files :: Maybe [FileObject]
+  , attachments :: Maybe [MessageAttachment]
   }
   deriving stock (Show)
 

--- a/test/Slacklinker/Handler/TestData.hs
+++ b/test/Slacklinker/Handler/TestData.hs
@@ -1,0 +1,133 @@
+module Slacklinker.Handler.TestData where
+
+import Web.Slack.Conversation (ConversationId (..))
+import Web.Slack.Experimental.Blocks
+import Web.Slack.Experimental.Events.Types
+import Web.Slack.Types (TeamId (..), UserId (..))
+import Slacklinker.Import
+import Data.StringVariants (unsafeMkNonEmptyText)
+import Slacklinker.Handler.TestUtils
+
+ts1 :: Text
+ts1 = "1663971111.111111"
+
+ts2 :: Text
+ts2 = "1663972222.222222"
+
+-- real production event logged in test workspace
+forwardedMessageEvent :: MessageEvent
+forwardedMessageEvent =
+  MessageEvent
+    { blocks = Nothing,
+      channel = ConversationId {unConversationId = "C07KHDGQ7K3"},
+      text = "",
+      channelType = Channel,
+      files = Nothing,
+      user = UserId {unUserId = "U043H11ES4V"},
+      ts = "1725646557.141529",
+      threadTs = Nothing,
+      appId = Nothing,
+      botId = Nothing,
+      attachments =
+        Just
+          [ MessageAttachment
+              { fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
+                color = Just "D0D0D0",
+                pretext = Nothing,
+                authorName = Just "lev",
+                authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
+                authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                title = Nothing,
+                titleLink = Nothing,
+                text = Just "this message was forwarded",
+                fields = Nothing,
+                imageUrl = Nothing,
+                thumbUrl = Nothing,
+                footer = Just "Slack Conversation",
+                footerIcon = Nothing,
+                ts = Just "1725646540.483529",
+                isMsgUnfurl = Just True,
+                messageBlocks =
+                  Just
+                    [ AttachmentMessageBlock
+                        { team = TeamId {unTeamId = "T0123"},
+                          channel = ConversationId {unConversationId = "C043YJGBY49"},
+                          ts = "1725646540.483529",
+                          message =
+                            AttachmentMessageBlockMessage
+                              { blocks =
+                                  [ SlackBlockRichText (RichText
+                                      { blockId = Just (unsafeMkNonEmptyText "/dNUU"),
+                                        elements = [RichTextSectionItemRichText [RichItemText "this message was forwarded" (RichStyle {rsBold = False, rsItalic = False})]]
+                                      })
+                                  ]
+                              }
+                        }
+                    ],
+                authorId = Just (UserId {unUserId = "U043H11ES4V"}),
+                channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
+                channelTeam = Just (TeamId {unTeamId = "T0123"}),
+                isAppUnfurl = Nothing,
+                appUnfurlUrl = Nothing,
+                fromUrl = Just "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529"
+              }
+          ]
+    }
+
+-- synthetic event, modified from above, with an attachment that has a URL, but wasnt a forwarded message (no fromurl)
+attachedUrlEvent :: MessageEvent
+attachedUrlEvent =
+  MessageEvent
+    { blocks = Nothing,
+      channel = ConversationId {unConversationId = "C07KHDGQ7K3"},
+      text = "",
+      channelType = Channel,
+      files = Nothing,
+      user = UserId {unUserId = "U043H11ES4V"},
+      ts = "1725646557.141529",
+      threadTs = Nothing,
+      appId = Nothing,
+      botId = Nothing,
+      attachments =
+        Just
+          [ MessageAttachment
+              { fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
+                color = Just "D0D0D0",
+                pretext = Nothing,
+                authorName = Just "lev",
+                authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
+                authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                title = Nothing,
+                titleLink = Nothing,
+                text = Just "this message was forwarded",
+                fields = Nothing,
+                imageUrl = Nothing,
+                thumbUrl = Nothing,
+                footer = Just "Slack Conversation",
+                footerIcon = Nothing,
+                ts = Just "1725646540.483529",
+                isMsgUnfurl = Just True,
+                messageBlocks =
+                  Just
+                    [ AttachmentMessageBlock
+                        { team = TeamId {unTeamId = "T0123"},
+                          channel = ConversationId {unConversationId = "C043YJGBY49"},
+                          ts = "1725646540.483529",
+                          message =
+                            AttachmentMessageBlockMessage
+                              { blocks =
+                                  [ SlackBlockRichText (urlRichText "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529")
+                                  ]
+                              }
+                        }
+                    ],
+                authorId = Just (UserId {unUserId = "U043H11ES4V"}),
+                channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
+                channelTeam = Just (TeamId {unTeamId = "T0123"}),
+                isAppUnfurl = Nothing,
+                appUnfurlUrl = Nothing,
+                fromUrl = Nothing
+              }
+          ]
+    }
+

--- a/test/Slacklinker/Handler/TestUtils.hs
+++ b/test/Slacklinker/Handler/TestUtils.hs
@@ -1,0 +1,84 @@
+module Slacklinker.Handler.TestUtils where
+
+import Web.Slack.Conversation (ConversationId (..))
+import Web.Slack.Experimental.Blocks
+import Web.Slack.Experimental.Events.Types
+import Web.Slack.Types (UserId (..))
+import Slacklinker.Import
+import TestImport
+import Slacklinker.SplitUrl (SlackUrlParts (..), splitSlackUrl)
+
+sampleUrl :: (Text, SlackUrlParts)
+sampleUrl = (url, fromJust $ splitSlackUrl url)
+  where
+    url = "https://jadeapptesting.slack.com/archives/C045V0VJT16/p1665014817153719"
+
+sampleUrlToChild :: (Text, SlackUrlParts)
+sampleUrlToChild = (url, fromJust $ splitSlackUrl url)
+  where
+    url = "https://jadeapptesting.slack.com/archives/C045V0VJT16/p1668735634647249?thread_ts=1665014817.153719&cid=C045V0VJT16"
+
+urlRichText :: Text -> RichText
+urlRichText url =
+  RichText
+    { blockId = Nothing
+    , elements =
+        [ RichTextSectionItemRichText
+            [ RichItemLink
+                ( RichLinkAttrs
+                    { style = RichStyle {rsBold = False, rsItalic = False}
+                    , url
+                    , text = Nothing
+                    }
+                )
+            ]
+        ]
+    }
+
+richTextToMaybeUrl :: RichText -> Maybe Text
+richTextToMaybeUrl rt = listToMaybe $ concatMap fromRichSectionItem rt.elements
+  where
+    fromRichSectionItem (RichTextSectionItemRichText items) = concatMap fromRichItem items
+    fromRichSectionItem _ = []
+
+    fromRichItem (RichItemLink attrs) = [url attrs]
+    fromRichItem _ = []
+
+messageEventWithBlocks :: Text -> [SlackBlock] -> MessageEvent
+messageEventWithBlocks ts blocks =
+  MessageEvent
+    { blocks = Just blocks
+    , channel = ConversationId "C043YJGBY49"
+    , text = "nobody looks at this"
+    , channelType = Channel
+    , user = UserId "U043H11ES4V"
+    , ts
+    , files = Nothing
+    , threadTs = Nothing
+    , appId = Nothing
+    , botId = Nothing
+    , attachments = Nothing
+    }
+
+botMessageEventWithBlocks :: Text -> [SlackBlock] -> BotMessageEvent
+botMessageEventWithBlocks ts blocks =
+  BotMessageEvent
+    { blocks = Just blocks
+    , channel = ConversationId "C043YJGBY49"
+    , text = "nobody looks at this"
+    , channelType = Channel
+    , ts
+    , files = Nothing
+    , threadTs = Nothing
+    , appId = Just "XYZ123"
+    , botId = "123XYZ"
+    , attachments = Nothing
+    }
+
+-- XXX: lol, DuplicateRecordFields makes update syntax not work if two fields
+-- of the same name are in scope
+updateThreadTs :: MessageEvent -> Maybe Text -> MessageEvent
+updateThreadTs MessageEvent {..} newThreadTs = MessageEvent {threadTs = newThreadTs, ..}
+
+updateChannelId :: MessageEvent -> ConversationId -> MessageEvent
+updateChannelId MessageEvent {..} newChannelId = MessageEvent {channel = newChannelId, ..}


### PR DESCRIPTION
adds both forwards (using slack's undocumented `fromUrl` api) and attachments (using slack's well-documented attachment api that is unfortunately not used for forwards)

tested in prod pretty thoroughly

two separate messages:
<img width="389" alt="image" src="https://github.com/user-attachments/assets/88812e14-7b74-4c48-a19c-cd3d80a233c8">

copy link of second one:
<img width="740" alt="image" src="https://github.com/user-attachments/assets/516d77d0-5d7d-476b-aac1-1b74dd6ee40d">

forward first one:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/c4c99f59-ba3d-4c42-ad95-ac68c92fe466">

pasting copied link into forwarded quote text (not that slack does not preview the copied message, only the forwarded one):
<img width="497" alt="image" src="https://github.com/user-attachments/assets/cafaf4ee-90fb-4650-8cf6-e81fda4ad72d">

resulting message posted has two unfurls, one from forward, one from linked:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/cd716672-675e-4ce8-b584-c91711c0935e">

slacklinker links both:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/5a60a6e2-90f0-4612-9c9f-7930f97f1909">
