### PR TITLE
deconstruct unparseable payload into otel attribute list

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - pretty-simple
   - resource-pool
   - safe
+  - scientific
   - servant
   - servant-client
   - servant-client-core

--- a/src/Slacklinker/Tracing.hs
+++ b/src/Slacklinker/Tracing.hs
@@ -4,12 +4,19 @@ module Slacklinker.Tracing (
   OTel.defaultSpanArguments,
   withGlobalTracing,
   withCurrentSpan,
+  flattenJsonToAttributes
 ) where
 
+import OpenTelemetry.Attributes
 import OpenTelemetry.Context qualified as OTel
 import OpenTelemetry.Context.ThreadLocal qualified as Context
 import OpenTelemetry.Trace qualified as OTel
 import Slacklinker.Prelude hiding (traceId)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Scientific qualified as Scientific
+import Data.Vector qualified as Vector
 
 getTracer :: MonadIO m => m OTel.Tracer
 getTracer = do
@@ -37,3 +44,29 @@ withGlobalTracing act =
     (liftIO OTel.initializeGlobalTracerProvider)
     (liftIO . OTel.shutdownTracerProvider)
     (const act)
+
+-- | Flatten a JSON value into one or more attributes.
+-- Dot-separated keys are used to represent nested objects.
+-- Array indices are represented as [n].
+flattenJsonToAttributes :: Text -> Aeson.Value -> [(Text, Attribute)]
+flattenJsonToAttributes attributePrefix = \case
+  Aeson.Object o ->
+    let keysAndValues = KeyMap.toList o
+        flattenObject (k, v) = flattenJsonToAttributes (attributePrefix <> "." <> Key.toText k) v
+     in concatMap flattenObject keysAndValues
+  Aeson.Array xs ->
+    let indexedVector = Vector.indexed xs
+        flattenVector (i, v) = flattenJsonToAttributes (attributePrefix <> "[" <> tshow i <> "]") v
+     in concatMap flattenVector indexedVector
+  Aeson.String x ->
+    [(attributePrefix, toAttribute x)]
+  Aeson.Number x ->
+    case Scientific.floatingOrInteger x of
+      Left d ->
+        [(attributePrefix, toAttribute @Double d)]
+      Right i ->
+        [(attributePrefix, toAttribute @Int64 i)]
+  Aeson.Bool x ->
+    [(attributePrefix, toAttribute x)]
+  Aeson.Null ->
+    [(attributePrefix, toAttribute @Text "null")]


### PR DESCRIPTION
This helps us debug until https://github.com/iand675/hs-opentelemetry/tree/attribute-length-limit-fix is merged and working