### PR TITLE
raw attachments

### DIFF
--- a/nix/deps/slack-web.nix
+++ b/nix/deps/slack-web.nix
@@ -14,8 +14,8 @@ mkDerivation {
   version = "2.0.0.4";
   src = fetchgit {
     url = "https://github.com/MercuryTechnologies/slack-web";
-    sha256 = "87d0cdaa5ba79e4fbb0ec89212bc319499c11bed199bcd88e735cafbce171023";
-    rev = "49b997b0093c2d1e35292a9ef5721ed7c9fa3381";
+    sha256 = "sha256-sMmlGMzbj8xy+joqN/Ohok1Q+B3pZDUFCMnqu5xi+a8=";
+    rev = "649186a790a79547ecd16836af5789c93a195a95";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/deps/slack-web.nix
+++ b/nix/deps/slack-web.nix
@@ -11,11 +11,11 @@
 }:
 mkDerivation {
   pname = "slack-web";
-  version = "2.0.0.3";
+  version = "2.0.0.4";
   src = fetchgit {
     url = "https://github.com/MercuryTechnologies/slack-web";
-    sha256 = "0dpa7nzpzvmrpqh1brr44vw97liij8bn2a96v430gmik507cs5f4";
-    rev = "4dc4e3c328b5643ce3ecad244d9b32496213fa86";
+    sha256 = "87d0cdaa5ba79e4fbb0ec89212bc319499c11bed199bcd88e735cafbce171023";
+    rev = "49b997b0093c2d1e35292a9ef5721ed7c9fa3381";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
   - http-client-tls
   - http-media
   - http-types
+  - megaparsec
   - monad-logger
   - mono-traversable
   - network-uri

--- a/src/Slacklinker/Extract/Parse.hs
+++ b/src/Slacklinker/Extract/Parse.hs
@@ -1,24 +1,23 @@
 module Slacklinker.Extract.Parse (
-    extractUrls
-    , extractRawLinks
-    , parseUrl
-)
-where
+  extractUrls,
+  extractRawLinks,
+  parseUrl,
+) where
 
+import Control.Applicative (pure, (*>), (<*))
+import Control.Monad (void)
 import Data.Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Function (($), (.))
+import Data.List (concatMap)
+import Data.Maybe
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
+import Data.Tuple (snd)
+import Data.Vector qualified as V
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import Data.Maybe
-import Data.Function ((.), ($))
-import Control.Applicative ((<*), (*>), pure)
-import Data.Aeson.KeyMap qualified as KeyMap
-import Data.List (concatMap)
-import Data.Tuple (snd)
-import Control.Monad (void)
-import Data.Vector qualified as V
 
 type Parser = Parsec Void Text
 
@@ -33,7 +32,6 @@ parseUrl subdomain = try $ do
   timestamp <- some digitChar
   pure $ T.concat ["https://", subdomain, ".slack.com/archives/", T.pack channelId, "/p", T.pack timestamp]
 
-
 extractUrls :: Text -> Text -> [Text]
 extractUrls subdomain input = fromMaybe [] $ parseMaybe urlsParser input
   where
@@ -44,7 +42,7 @@ extractUrls subdomain input = fromMaybe [] $ parseMaybe urlsParser input
     -- Parse a list of URLs
     urlsParser :: Parser [Text]
     urlsParser = many (notUrl *> parseUrl' <* notUrl)
-    
+
     -- Consume any non-URL characters (zero or more)
     notUrl :: Parser ()
     notUrl = skipMany $ notFollowedBy parseUrl' *> anySingle

--- a/src/Slacklinker/Extract/Parse.hs
+++ b/src/Slacklinker/Extract/Parse.hs
@@ -1,0 +1,57 @@
+module Slacklinker.Extract.Parse (
+    extractUrls
+    , extractRawLinks
+    , parseUrl
+)
+where
+
+import Data.Aeson
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Void
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import Data.Maybe
+import Data.Function ((.), ($))
+import Control.Applicative ((<*), (*>), pure)
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.List (concatMap)
+import Data.Tuple (snd)
+import Control.Monad (void)
+import Data.Vector qualified as V
+
+type Parser = Parsec Void Text
+
+parseUrl :: Text -> Parser Text
+parseUrl subdomain = try $ do
+  void $ string "https://"
+  void $ string subdomain
+  void $ string ".slack.com/archives/"
+  channelId <- some (alphaNumChar <|> char '-')
+  void $ char '/'
+  void $ char 'p'
+  timestamp <- some digitChar
+  pure $ T.concat ["https://", subdomain, ".slack.com/archives/", T.pack channelId, "/p", T.pack timestamp]
+
+
+extractUrls :: Text -> Text -> [Text]
+extractUrls subdomain input = fromMaybe [] $ parseMaybe urlsParser input
+  where
+    -- fix subdomain
+    parseUrl' :: Parser Text
+    parseUrl' = parseUrl subdomain
+
+    -- Parse a list of URLs
+    urlsParser :: Parser [Text]
+    urlsParser = many (notUrl *> parseUrl' <* notUrl)
+    
+    -- Consume any non-URL characters (zero or more)
+    notUrl :: Parser ()
+    notUrl = skipMany $ notFollowedBy parseUrl' *> anySingle
+
+-- Recursively extract strings from JSON and apply URL extraction
+extractRawLinks :: Text -> Value -> [Text]
+extractRawLinks slackSubdomain (Object obj) = concatMap (extractRawLinks slackSubdomain . snd) (KeyMap.toList obj)
+extractRawLinks slackSubdomain (Array arr) = concatMap (extractRawLinks slackSubdomain) (V.toList arr)
+extractRawLinks slackSubdomain (String str) = extractUrls slackSubdomain str
+extractRawLinks _ _ = []

--- a/src/Slacklinker/Extract/Types.hs
+++ b/src/Slacklinker/Extract/Types.hs
@@ -17,6 +17,7 @@ data ExtractedMessageData = ExtractedMessageData
   , blocks :: Maybe [SlackBlock]
   , files :: Maybe [FileObject]
   , attachments :: Maybe [MessageAttachment]
+  , appId :: Maybe Text
   }
   deriving stock (Show)
 

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -17,7 +17,7 @@ import Database.Persist
 import Generics.Deriving.ConNames (conNameOf)
 import OpenTelemetry.Trace.Core (Span, addAttribute, addAttributes, ToAttribute (toAttribute), Attribute)
 import Slacklinker.App
-import Slacklinker.Exceptions (UnknownWorkspace(UnknownWorkspace), VerificationException(VerificationException))
+import Slacklinker.Exceptions
 import Slacklinker.Handler.Webhook.ImCommand (handleImCommand)
 import Slacklinker.Import
 import Slacklinker.Models

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -15,9 +15,11 @@ import Data.Aeson.Types (Parser, parse)
 import Data.HashMap.Strict qualified as HashMap
 import Database.Persist
 import Generics.Deriving.ConNames (conNameOf)
-import OpenTelemetry.Trace.Core (Span, addAttribute, addAttributes)
+import OpenTelemetry.Trace.Core (Span, addAttribute, addAttributes, ToAttribute (toAttribute), Attribute)
 import Slacklinker.App
 import Slacklinker.Exceptions
+    ( UnknownWorkspace(UnknownWorkspace),
+      VerificationException(VerificationException) )
 import Slacklinker.Handler.Webhook.ImCommand (handleImCommand)
 import Slacklinker.Import
 import Slacklinker.Models
@@ -30,11 +32,11 @@ import Web.Slack.Experimental.RequestVerification (SlackRequestTimestamp, SlackS
 import Web.Slack.Types (TeamId (..))
 import Web.Slack.Types qualified as Slack (UserId (..))
 import Slacklinker.Extract.Types
+import Slacklinker.Extract.Parse (extractRawLinks)
 import Data.List (nub)
 
 extractBlockLinks :: SlackBlock -> [Text]
-extractBlockLinks block =
-  fromBlock block
+extractBlockLinks = fromBlock
   where
     fromBlock (SlackBlockRichText rt) = fromRichText rt
     fromBlock _ = []
@@ -46,14 +48,14 @@ extractBlockLinks block =
     fromRichItem (RichItemLink RichLinkAttrs {..}) = [url]
     fromRichItem _ = []
 
-extractAttachedLinks :: MessageAttachment -> [Text]
-extractAttachedLinks attachment = concat [fromUrlLinks, blockLinks]
+extractAttachedLinks :: DecodedMessageAttachment -> [Text]
+extractAttachedLinks attachment = fromUrlLinks ++ blockLinks
   where
     fromUrlLinks :: [Text]
     fromUrlLinks = maybeToList attachment.fromUrl
 
     blockLinks :: [Text]
-    blockLinks = concatMap extractBlockLinksFromMessageBlock (fromMaybe [] attachment.messageBlocks)
+    blockLinks =  maybe [] (concatMap extractBlockLinksFromMessageBlock) attachment.messageBlocks
 
     extractBlockLinksFromMessageBlock :: AttachmentMessageBlock -> [Text]
     extractBlockLinksFromMessageBlock messageBlock = concatMap extractBlockLinks messageBlock.message.blocks
@@ -139,19 +141,21 @@ workspaceByTeamId teamId = (runDB $ getBy $ UniqueWorkspaceSlackId teamId) >>= (
 
 handleMessage :: (HasApp m, MonadUnliftIO m, ExtractableMessage em) => em -> TeamId -> m ()
 handleMessage msg teamId = do
-  workspace <- workspaceByTeamId teamId
+  -- workspace <- workspaceByTeamId teamId
+  workspaceE@(Entity workspaceId workspace) <- workspaceByTeamId teamId
   case ev.channelType of
     Channel -> do
       let blockLinks = mconcat $ extractBlockLinks <$> fromMaybe [] ev.blocks
-          attachedLinks = mconcat $ extractAttachedLinks <$> fromMaybe [] ev.attachments
-          links = nub $ blockLinks <> attachedLinks
-      repliedThreadIds <- mapMaybeM (handleUrl $ entityKey workspace) links
+          attachedLinks = mconcat $ extractAttachedLinks <$> mapMaybe decoded (fromMaybe [] ev.attachments)
+          rawLinks = mconcat $ extractRawLinks workspace.slackSubdomain <$> maybe [] (map raw) ev.attachments
+          links = nub $ blockLinks <> attachedLinks <> rawLinks
+      repliedThreadIds <- mapMaybeM (handleUrl workspaceId) links
       -- this is like a n+1 query of STM, which is maybe bad for perf vs running
       -- it one action, but whatever
       forM_ repliedThreadIds $ \todo -> do
         for_ todo $ senderEnqueue . UpdateReply
     Im -> do
-      handleImCommand (workspaceMetaFromWorkspaceE workspace) ev.channel ev.text ev.files
+      handleImCommand (workspaceMetaFromWorkspaceE workspaceE) ev.channel ev.text ev.files
     Group ->
       -- we don't do these
       pure ()
@@ -171,87 +175,148 @@ handleMessage msg teamId = do
         userId <- recordUser workspaceId ev.user
         recordLink workspaceId userId linkSource linkDestination
 
-handleCallback :: Event -> TeamId -> Span -> AppM Value
-handleCallback (EventMessage ev) teamId span | isNothing ev.botId = do
-  blocklist <- getsApp (.config.blockedAppIds)
-  case ev.appId of
-    -- its unclear why sometimes slack sends the event with subtype bot_message
-    -- and sometimes without it. in case slack's behavior changes in the future,
-    -- we really want to prevent infinite loops, so we check the blocklist here
-    -- as well
-    Just appId | appId `elem` blocklist -> pure $ Object mempty
-    _ -> do
+addEventAttributes :: Event -> TeamId -> Span -> AppM ()
+addEventAttributes event teamId span = do
+  addAttribute span "slack.team.id" teamId.unTeamId
+  case event of
+    EventMessage ev -> do
+      addAttribute span "slack.event.type" ("message" :: Text)
       addAttribute span "slack.conversation.id" ev.channel.unConversationId
       addAttribute span "slack.event.appId" (fromMaybe "" ev.appId)
-      addAttribute span "slack.event.isMsgUnfurl" $ maybe False (any (maybe False (== True) . isMsgUnfurl)) ev.attachments
-      handleMessage ev teamId
-      pure $ Object mempty
--- a regular message with no subtype, but one that has a botId
-handleCallback (EventMessage _ev) _ _ = pure $ Object mempty
--- a message with bot_message subtype
-handleCallback (EventBotMessage ev) teamId span = do
-  blocklist <- getsApp (.config.blockedAppIds)
-  case ev.appId of
-    Just appId | appId `elem` blocklist -> pure $ Object mempty
-    _ -> do
+      addAttribute span "slack.event.botId" (fromMaybe "" ev.botId)
+      addAttachmentAttributes ev.attachments span
+    EventBotMessage ev -> do
+      addAttribute span "slack.event.type" ("message" :: Text)
+      addAttribute span "slack.event.subtype" ("bot_message" :: Text)
       addAttribute span "slack.conversation.id" ev.channel.unConversationId
       addAttribute span "slack.event.appId" (fromMaybe "" ev.appId)
-      addAttribute span "slack.event.isMsgUnfurl" $ maybe False (any (maybe False (== True) . isMsgUnfurl)) ev.attachments
-      handleMessage ev teamId
-      pure $ Object mempty
-handleCallback (EventMessageChanged) _ _ = pure $ Object mempty
-handleCallback (EventChannelJoinMessage) _ _ = pure $ Object mempty
-handleCallback (EventChannelCreated createdEvent) teamId _ = do
-  -- join new channels
-  -- FIXME(jadel): should this be configurable behaviour?
-  Entity workspaceId workspace <- workspaceByTeamId teamId
-  senderEnqueue $
-    JoinChannel
+      addAttribute span "slack.event.botId" ev.botId
+      addAttachmentAttributes ev.attachments span
+    EventMessageChanged -> do
+      addAttribute span "slack.event.type" ("message" :: Text)
+      addAttribute span "slack.event.subtype" ("message_changed" :: Text)
+      pure ()
+    EventChannelJoinMessage -> do
+      addAttribute span "slack.event.type" ("message" :: Text)
+      addAttribute span "slack.event.subtype" ("channel_join" :: Text)
+      pure ()
+    EventChannelCreated ev -> do
+      addAttribute span "slack.event.type" ("channel_created" :: Text)
+      addAttribute span "slack.channel.id" ev.channel.id.unConversationId
+      addAttribute span "slack.channel.name" ev.channel.name
+      addAttribute span "slack.channel.team.id" ev.channel.contextTeamId.unTeamId
+    EventChannelLeft ev -> do
+      addAttribute span "slack.event.type" ("channel_left" :: Text)
+      addAttribute span "slack.channel.id" ev.channel.unConversationId
+      addAttribute span "slack.channel.actor.id" ev.actorId.unUserId
+    EventUnknown v -> case parse unknownAttributes v of
+        Success attrs -> for_ attrs \(attrName, attrVal) -> addAttribute span ("slack.event." <> attrName) attrVal
+        _ -> pure ()
+
+  pure ()
+  where
+    addAttachmentAttributes :: Maybe [MessageAttachment] -> Span -> AppM ()
+    addAttachmentAttributes mAttachments s = do
+      addAttribute s "slack.event.hasAttachments" $ maybe False (not . null) mAttachments
+      addAttribute s "slack.event.numAttachments" $ maybe 0 length mAttachments
+      case mAttachments of
+        Nothing -> pure ()
+        Just attachments -> do
+          addAttribute s "slack.event.attachments.hasMsgUnfurl" $ any hasMsgUnfurl attachments
+          addAttribute s "slack.event.attachments.hasNoMessageBlocks" $ any hasNoMessageBlocks attachments
+          addAttribute s "slack.event.attachments.hasUndecodable" $ any hasUndecodable attachments
+      pure ()
+    
+    hasMsgUnfurl  :: MessageAttachment -> Bool
+    hasMsgUnfurl = fromMaybe False . (decoded >=> isMsgUnfurl)
+
+    -- decoded >=> (pure . isNothing . messageBlocks) - if decoding succeeds, checks if its messageBlocks field is Nothing
+    -- fromMaybe True - if decoding fails, we treat it as having no message blocks (True)
+    hasNoMessageBlocks :: MessageAttachment -> Bool
+    hasNoMessageBlocks = fromMaybe True . (decoded >=> (pure . isNothing . messageBlocks))
+
+    hasUndecodable :: MessageAttachment -> Bool
+    hasUndecodable = isNothing . decoded
+
+    filterMaybes :: [(a, Maybe b)] -> [(a, b)]
+    filterMaybes = mapMaybe sequenceA
+
+    unknownAttributes :: Value -> Parser [(Text, Attribute)]
+    unknownAttributes = withObject "webhook event" \val -> do
+      type_ <- val .: "type" :: Parser Text
+      subtype <- val .:? "subtype" :: Parser (Maybe Text)
+      appId <- val .:? "app_id" :: Parser (Maybe Text)
+      botId <- val .:? "bot_id" :: Parser (Maybe Text)
+      userId <- val .:? "user" :: Parser (Maybe Text)
+      channelId <- val .:? "channel" :: Parser (Maybe Text)
+      ts <- val .:? "ts" :: Parser (Maybe Text)
+      team <- val .:? "team" :: Parser (Maybe Text)
+      attachments <- val .:? "attachments" :: Parser (Maybe [Value])
+      pure $ filterMaybes
+        [ ("type", Just $ toAttribute type_)
+        , ("subtype", toAttribute <$> subtype)
+        , ("appId", toAttribute <$> appId)
+        , ("botId", toAttribute <$> botId)
+        , ("userId", toAttribute <$> userId)
+        , ("channelId", toAttribute <$> channelId)
+        , ("ts", toAttribute <$> ts)
+        , ("team", toAttribute <$> team)
+        , ("hasAttachments", Just . toAttribute . maybe False (not . null) $ attachments)
+        , ("numAttachments", Just . toAttribute . maybe 0 length $ attachments)
+        ]
+
+handleCallback :: Event -> TeamId -> AppM ()
+handleCallback event teamId = case event of
+  -- Handle both regular and bot messages uniformly. 
+  -- Some regular messages may actually be bot messages, maybe legacy bots.
+  EventMessage ev -> handleMessage' ev 
+  EventBotMessage ev -> handleMessage' ev
+  
+  -- Join newly created channels
+  EventChannelCreated ev -> do
+    Entity workspaceId workspace <- workspaceByTeamId teamId
+    senderEnqueue $ JoinChannel 
       WorkspaceMeta
         { slackTeamId = workspace.slackTeamId
         , token = workspace.slackOauthToken
         , workspaceId
         }
-      createdEvent.channel.id
-  pure $ Object mempty
-handleCallback (EventChannelLeft l) teamId _ = do
-  -- remove our database entry stating we're in it
-  Entity wsId _ <- workspaceByTeamId teamId
-  runDB $ do
-    deleteBy $ UniqueJoinedChannel wsId l.channel
-  pure $ Object mempty
-handleCallback (EventUnknown v) _ span = do
-  case parse typeAndSubtypeAndAppId v of
-    Success (type_, subtype, appId) -> do
-      addAttribute span "slack.event.type" type_
-      addAttribute span "slack.event.subtype" (fromMaybe "" subtype)
-      addAttribute span "slack.event.appId" (fromMaybe "" appId)
-      logUnknown
-    _ -> logUnknown
-  pure $ Object mempty
-  where
-    logUnknown = logDebug $ "unknown webhook callback: " <> tshow v
+      ev.channel.id
+      
+  -- If slacklinker was removed from a channel, remove the database entry
+  EventChannelLeft ev -> do
+    Entity wsId _ <- workspaceByTeamId teamId
+    runDB $ deleteBy $ UniqueJoinedChannel wsId ev.channel
+    
+  -- No-op events
+  EventMessageChanged -> pure ()
+  EventChannelJoinMessage -> pure ()
 
-    typeAndSubtypeAndAppId :: Value -> Parser (Text, Maybe Text, Maybe Text)
-    typeAndSubtypeAndAppId = withObject "webhook event" \val -> do
-      type_ <- val .: "type"
-      subtype <- val .:? "subtype"
-      appId <- val .:? "app_id"
-      pure (type_, subtype, appId)
+  -- Log unknown events
+  EventUnknown v -> logDebug $ "unknown webhook callback: " <> tshow v
+  where
+    handleMessage' :: (HasApp m, MonadUnliftIO m, ExtractableMessage em) => em -> m ()
+    handleMessage' ev = do
+      blocklist <- getsApp (.config.blockedAppIds)
+      case (extractData ev).appId of
+        Just appId | appId `elem` blocklist -> pure ()
+        _ -> handleMessage ev teamId
 
 handleEvent :: SlackWebhookEvent -> AppM Value
 handleEvent (EventUrlVerification UrlVerificationPayload {..}) = do
   pure . toJSON $ UrlVerificationResponse {challenge}
 handleEvent (EventEventCallback EventCallback {event, teamId}) = do
   inSpan' (cs $ conNameOf event) defaultSpanArguments \span -> do
-    addAttribute span "slack.team.id" teamId.unTeamId
-    handleCallback event teamId span
+    addEventAttributes event teamId span
+    handleCallback event teamId
+    pure $ Object mempty
 handleEvent (EventUnknownWebhook v) = do
   logInfo $ "unknown webhook event: " <> tshow v
   pure $ Object mempty
 
 postSlackInteractiveWebhookR :: SlackSignature -> SlackRequestTimestamp -> ByteString -> AppM Value
 postSlackInteractiveWebhookR sig ts body = do
+  logDebug $ "hello"
   secret <- getsApp (.config.slackSigningSecret)
   ePayload <- validateRequest secret sig ts body
   case ePayload of

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -315,7 +315,6 @@ handleEvent (EventUnknownWebhook v) = do
 
 postSlackInteractiveWebhookR :: SlackSignature -> SlackRequestTimestamp -> ByteString -> AppM Value
 postSlackInteractiveWebhookR sig ts body = do
-  logDebug $ "hello"
   secret <- getsApp (.config.slackSigningSecret)
   ePayload <- validateRequest secret sig ts body
   case ePayload of

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -17,9 +17,7 @@ import Database.Persist
 import Generics.Deriving.ConNames (conNameOf)
 import OpenTelemetry.Trace.Core (Span, addAttribute, addAttributes, ToAttribute (toAttribute), Attribute)
 import Slacklinker.App
-import Slacklinker.Exceptions
-    ( UnknownWorkspace(UnknownWorkspace),
-      VerificationException(VerificationException) )
+import Slacklinker.Exceptions (UnknownWorkspace(UnknownWorkspace), VerificationException(VerificationException))
 import Slacklinker.Handler.Webhook.ImCommand (handleImCommand)
 import Slacklinker.Import
 import Slacklinker.Models
@@ -241,6 +239,7 @@ addEventAttributes event teamId span = do
     filterMaybes :: [(a, Maybe b)] -> [(a, b)]
     filterMaybes = mapMaybe sequenceA
 
+    -- adding these helps with debugging and adding new features to slacklinker
     unknownAttributes :: Value -> Parser [(Text, Attribute)]
     unknownAttributes = withObject "webhook event" \val -> do
       type_ <- val .: "type" :: Parser Text

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -53,7 +53,7 @@ extractAttachedLinks attachment = fromUrlLinks ++ blockLinks
     fromUrlLinks = maybeToList attachment.fromUrl
 
     blockLinks :: [Text]
-    blockLinks =  maybe [] (concatMap extractBlockLinksFromMessageBlock) attachment.messageBlocks
+    blockLinks = maybe [] (concatMap extractBlockLinksFromMessageBlock) attachment.messageBlocks
 
     extractBlockLinksFromMessageBlock :: AttachmentMessageBlock -> [Text]
     extractBlockLinksFromMessageBlock messageBlock = concatMap extractBlockLinks messageBlock.message.blocks
@@ -139,7 +139,6 @@ workspaceByTeamId teamId = (runDB $ getBy $ UniqueWorkspaceSlackId teamId) >>= (
 
 handleMessage :: (HasApp m, MonadUnliftIO m, ExtractableMessage em) => em -> TeamId -> m ()
 handleMessage msg teamId = do
-  -- workspace <- workspaceByTeamId teamId
   workspaceE@(Entity workspaceId workspace) <- workspaceByTeamId teamId
   case ev.channelType of
     Channel -> do

--- a/test/Slacklinker/Extract/ParseSpec.hs
+++ b/test/Slacklinker/Extract/ParseSpec.hs
@@ -1,7 +1,7 @@
 module Slacklinker.Extract.ParseSpec (spec) where
 
-import TestImport
 import Slacklinker.Extract.Parse (extractUrls)
+import TestImport
 
 spec :: Spec
 spec = describe "Free Text URL Parsing" do
@@ -23,4 +23,3 @@ spec = describe "Free Text URL Parsing" do
   it "Parses URLs with newlines and formatting" do
     let urls = extractUrls "myteam" "this is a fake pr with a link\n\n<https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>\n and some content"
     urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249", "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"]
-  

--- a/test/Slacklinker/Extract/ParseSpec.hs
+++ b/test/Slacklinker/Extract/ParseSpec.hs
@@ -1,0 +1,26 @@
+module Slacklinker.Extract.ParseSpec (spec) where
+
+import TestImport
+import Slacklinker.Extract.Parse (extractUrls)
+
+spec :: Spec
+spec = describe "Free Text URL Parsing" do
+  it "Parses just the url" do
+    let urls = extractUrls "myteam" "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"]
+  it "Parses multiple URLs" do
+    let urls = extractUrls "myteam" "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249 https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629250"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249", "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629250"]
+  it "Parses URLs with text before it" do
+    let urls = extractUrls "myteam" "this is a fake pr with a link https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"]
+  it "Parses URLs with text after it" do
+    let urls = extractUrls "myteam" "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249 some text here"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"]
+  it "Parses many URLs with text inline" do
+    let urls = extractUrls "myteam" "some other text https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249 some https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629250 text here"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249", "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629250"]
+  it "Parses URLs with newlines and formatting" do
+    let urls = extractUrls "myteam" "this is a fake pr with a link\n\n<https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>\n and some content"
+    urls `shouldBe` ["https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249", "https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249"]
+  

--- a/test/Slacklinker/Handler/TestData.hs
+++ b/test/Slacklinker/Handler/TestData.hs
@@ -3,14 +3,14 @@ module Slacklinker.Handler.TestData where
 import Data.Aeson (Value(Object))
 import Data.Aeson qualified as A
 import Data.Aeson.KeyMap qualified as KM
+import Data.StringVariants (unsafeMkNonEmptyText)
 import Data.Vector qualified as V
 import Web.Slack.Conversation (ConversationId (..))
 import Web.Slack.Experimental.Blocks
 import Web.Slack.Experimental.Events.Types
 import Web.Slack.Types (TeamId (..), UserId (..))
-import Slacklinker.Import
-import Data.StringVariants (unsafeMkNonEmptyText)
 import Slacklinker.Handler.TestUtils ( urlRichText )
+import Slacklinker.Import
 
 emptyJsonObject :: Value
 emptyJsonObject = Object mempty

--- a/test/Slacklinker/Handler/TestData.hs
+++ b/test/Slacklinker/Handler/TestData.hs
@@ -1,19 +1,19 @@
 module Slacklinker.Handler.TestData where
 
+import Data.Aeson (Value(Object))
+import Data.Aeson qualified as A
+import Data.Aeson.KeyMap qualified as KM
+import Data.Vector qualified as V
 import Web.Slack.Conversation (ConversationId (..))
 import Web.Slack.Experimental.Blocks
 import Web.Slack.Experimental.Events.Types
 import Web.Slack.Types (TeamId (..), UserId (..))
 import Slacklinker.Import
 import Data.StringVariants (unsafeMkNonEmptyText)
-import Slacklinker.Handler.TestUtils
-import Data.Aeson (Value(Object))
-import Data.Aeson qualified as A
-import Data.Aeson.KeyMap qualified as KM
-import Data.Vector qualified as V
+import Slacklinker.Handler.TestUtils ( urlRichText )
 
 emptyJsonObject :: Value
-emptyJsonObject = Object KM.empty
+emptyJsonObject = Object mempty
 
 ts1 :: Text
 ts1 = "1663971111.111111"
@@ -166,11 +166,11 @@ messageWithUndecodableAttachment =
                 , attachments = Just
                     [ MessageAttachment
                         { decoded = Nothing
-                        , raw = A.Object
+                        , raw = Object
                             ( KM.fromList
                                 [
                                     ( "actions"
-                                    , A.Array $ V.fromList [ A.Object
+                                    , A.Array $ V.fromList [ Object
                                             ( KM.fromList
                                                 [
                                                     ( "id"

--- a/test/Slacklinker/Handler/TestData.hs
+++ b/test/Slacklinker/Handler/TestData.hs
@@ -7,6 +7,13 @@ import Web.Slack.Types (TeamId (..), UserId (..))
 import Slacklinker.Import
 import Data.StringVariants (unsafeMkNonEmptyText)
 import Slacklinker.Handler.TestUtils
+import Data.Aeson (Value(Object))
+import Data.Aeson qualified as A
+import Data.Aeson.KeyMap qualified as KM
+import Data.Vector qualified as V
+
+emptyJsonObject :: Value
+emptyJsonObject = Object KM.empty
 
 ts1 :: Text
 ts1 = "1663971111.111111"
@@ -31,45 +38,48 @@ forwardedMessageEvent =
       attachments =
         Just
           [ MessageAttachment
-              { fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
-                color = Just "D0D0D0",
-                pretext = Nothing,
-                authorName = Just "lev",
-                authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
-                authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
-                title = Nothing,
-                titleLink = Nothing,
-                text = Just "this message was forwarded",
-                fields = Nothing,
-                imageUrl = Nothing,
-                thumbUrl = Nothing,
-                footer = Just "Slack Conversation",
-                footerIcon = Nothing,
-                ts = Just "1725646540.483529",
-                isMsgUnfurl = Just True,
-                messageBlocks =
-                  Just
-                    [ AttachmentMessageBlock
-                        { team = TeamId {unTeamId = "T0123"},
-                          channel = ConversationId {unConversationId = "C043YJGBY49"},
-                          ts = "1725646540.483529",
-                          message =
-                            AttachmentMessageBlockMessage
-                              { blocks =
-                                  [ SlackBlockRichText (RichText
-                                      { blockId = Just (unsafeMkNonEmptyText "/dNUU"),
-                                        elements = [RichTextSectionItemRichText [RichItemText "this message was forwarded" (RichStyle {rsBold = False, rsItalic = False})]]
-                                      })
-                                  ]
-                              }
-                        }
-                    ],
-                authorId = Just (UserId {unUserId = "U043H11ES4V"}),
-                channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
-                channelTeam = Just (TeamId {unTeamId = "T0123"}),
-                isAppUnfurl = Nothing,
-                appUnfurlUrl = Nothing,
-                fromUrl = Just "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529"
+              { decoded = Just $ DecodedMessageAttachment { 
+                  fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
+                  color = Just "D0D0D0",
+                  pretext = Nothing,
+                  authorName = Just "lev",
+                  authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
+                  authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                  title = Nothing,
+                  titleLink = Nothing,
+                  text = Just "this message was forwarded",
+                  fields = Nothing,
+                  imageUrl = Nothing,
+                  thumbUrl = Nothing,
+                  footer = Just "Slack Conversation",
+                  footerIcon = Nothing,
+                  ts = Just "1725646540.483529",
+                  isMsgUnfurl = Just True,
+                  messageBlocks =
+                    Just
+                      [ AttachmentMessageBlock
+                          { team = TeamId {unTeamId = "T0123"},
+                            channel = ConversationId {unConversationId = "C043YJGBY49"},
+                            ts = "1725646540.483529",
+                            message =
+                              AttachmentMessageBlockMessage
+                                { blocks =
+                                    [ SlackBlockRichText (RichText
+                                        { blockId = Just (unsafeMkNonEmptyText "/dNUU"),
+                                          elements = [RichTextSectionItemRichText [RichItemText "this message was forwarded" (RichStyle {rsBold = False, rsItalic = False})]]
+                                        })
+                                    ]
+                                }
+                          }
+                      ],
+                  authorId = Just (UserId {unUserId = "U043H11ES4V"}),
+                  channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
+                  channelTeam = Just (TeamId {unTeamId = "T0123"}),
+                  isAppUnfurl = Nothing,
+                  appUnfurlUrl = Nothing,
+                  fromUrl = Just "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529"
+                },
+                raw = emptyJsonObject
               }
           ]
     }
@@ -91,43 +101,151 @@ attachedUrlEvent =
       attachments =
         Just
           [ MessageAttachment
-              { fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
-                color = Just "D0D0D0",
-                pretext = Nothing,
-                authorName = Just "lev",
-                authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
-                authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
-                title = Nothing,
-                titleLink = Nothing,
-                text = Just "this message was forwarded",
-                fields = Nothing,
-                imageUrl = Nothing,
-                thumbUrl = Nothing,
-                footer = Just "Slack Conversation",
-                footerIcon = Nothing,
-                ts = Just "1725646540.483529",
-                isMsgUnfurl = Just True,
-                messageBlocks =
-                  Just
-                    [ AttachmentMessageBlock
-                        { team = TeamId {unTeamId = "T0123"},
-                          channel = ConversationId {unConversationId = "C043YJGBY49"},
-                          ts = "1725646540.483529",
-                          message =
-                            AttachmentMessageBlockMessage
-                              { blocks =
-                                  [ SlackBlockRichText (urlRichText "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529")
-                                  ]
-                              }
-                        }
-                    ],
-                authorId = Just (UserId {unUserId = "U043H11ES4V"}),
-                channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
-                channelTeam = Just (TeamId {unTeamId = "T0123"}),
-                isAppUnfurl = Nothing,
-                appUnfurlUrl = Nothing,
-                fromUrl = Nothing
+              { decoded = Just $ DecodedMessageAttachment {
+                  fallback = Just "[September 6th, 2024 11:15 AM] lev: this message was forwarded",
+                  color = Just "D0D0D0",
+                  pretext = Nothing,
+                  authorName = Just "lev",
+                  authorLink = Just "https://myworkspace.slack.com/team/U043H11ES4V",
+                  authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                  title = Nothing,
+                  titleLink = Nothing,
+                  text = Just "this message was forwarded",
+                  fields = Nothing,
+                  imageUrl = Nothing,
+                  thumbUrl = Nothing,
+                  footer = Just "Slack Conversation",
+                  footerIcon = Nothing,
+                  ts = Just "1725646540.483529",
+                  isMsgUnfurl = Just True,
+                  messageBlocks =
+                    Just
+                      [ AttachmentMessageBlock
+                          { team = TeamId {unTeamId = "T0123"},
+                            channel = ConversationId {unConversationId = "C043YJGBY49"},
+                            ts = "1725646540.483529",
+                            message =
+                              AttachmentMessageBlockMessage
+                                { blocks =
+                                    [ SlackBlockRichText (urlRichText "https://myworkspace.slack.com/archives/C043YJGBY49/p1725646540483529")
+                                    ]
+                                }
+                          }
+                      ],
+                  authorId = Just (UserId {unUserId = "U043H11ES4V"}),
+                  channelId = Just (ConversationId {unConversationId = "C043YJGBY49"}),
+                  channelTeam = Just (TeamId {unTeamId = "T0123"}),
+                  isAppUnfurl = Nothing,
+                  appUnfurlUrl = Nothing,
+                  fromUrl = Nothing
+                },
+                raw = emptyJsonObject
               }
           ]
     }
 
+-- A PR was opened and the author linked a slack message in the PR description.
+-- When this is posted to slack, the slack message link can be backlinked.
+-- Note that we were actually able to decode parts of the message here, but
+-- we use a general parser to find the slack message link from the raw aeson Value.
+messageWithUndecodableAttachment :: MessageEvent
+messageWithUndecodableAttachment =
+              MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C07LRFB3C8M" }
+                , text = ""
+                , channelType = Channel
+                , files = Nothing
+                , user = UserId
+                    { unUserId = "U07M725KAD7" }
+                , ts = "1730339959.644979"
+                , threadTs = Nothing
+                , appId = Just "A01BP7R4KNY"
+                , botId = Just "B07LDR01Z63"
+                , attachments = Just
+                    [ MessageAttachment
+                        { decoded = Nothing
+                        , raw = A.Object
+                            ( KM.fromList
+                                [
+                                    ( "actions"
+                                    , A.Array $ V.fromList [ A.Object
+                                            ( KM.fromList
+                                                [
+                                                    ( "id"
+                                                    , A.String "1"
+                                                    )
+                                                ,
+                                                    ( "name"
+                                                    , A.String "comment"
+                                                    )
+                                                ,
+                                                    ( "style"
+                                                    , A.String ""
+                                                    )
+                                                ,
+                                                    ( "text"
+                                                    , A.String "Comment"
+                                                    )
+                                                ,
+                                                    ( "type"
+                                                    , A.String "button"
+                                                    )
+                                                ,
+                                                    ( "value"
+                                                    , A.String "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:669978765,&amp;amp;quot;number&amp;amp;quot;:8,&amp;amp;quot;htmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/pull/8&amp;amp;quot;,&amp;amp;quot;title&amp;amp;quot;:&amp;amp;quot;https://jadeapptesting.slack.com/archives/C07KTH1T4CQ/p1730339894629249&amp;amp;quot;}"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "callback_id"
+                                    , A.String "pr-opened-interaction"
+                                    )
+                                ,
+                                    ( "color"
+                                    , A.String "36a64f"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , A.String "[myorg/myrepo] Pull request opened by ldub"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , A.String "<https://github.com/myorg/myrepo|myorg/myrepo>"
+                                    )
+                                ,
+                                    ( "footer_icon"
+                                    , A.String "https://slack.github.com/static/img/favicon-neutral.png"
+                                    )
+                                ,
+                                    ( "id"
+                                    , A.Number 1.0
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , A.Array $ V.fromList [ A.String "text" ]
+                                    )
+                                ,
+                                    ( "pretext"
+                                    , A.String "Pull request opened by <https://github.com/ldub|ldub>"
+                                    )
+                                ,
+                                    ( "text"
+                                    , A.String "this is a fake pr with a link\n<https://jadeapptesting.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://jadeapptesting.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                    )
+                                ,
+                                    ( "title"
+                                    , A.String "<https://github.com/myorg/myrepo/pull/8|#8 https://jadeapptesting.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , A.Number 1.730339957e9
+                                    )
+                                ]
+                            )
+                        }
+                    ]
+                }

--- a/test/Slacklinker/Handler/WebhookSpec.hs
+++ b/test/Slacklinker/Handler/WebhookSpec.hs
@@ -118,6 +118,7 @@ spec = do
           theLink.threadTs `shouldBe` Nothing
           theLink.sent `shouldBe` False
     it "can find URLs in undecodable attachments" \app -> do
+      -- in this case, slacklinker will run the url detection parser on the raw json
       runAppM app $ do
         (wsId, teamId) <- createWorkspace
         let msg = messageWithUndecodableAttachment
@@ -133,6 +134,7 @@ spec = do
         (Just (Entity channelId _)) <- runDB $ getBy $ UniqueJoinedChannel wsId msg.channel
 
         liftIO $ do
+          -- we check that decoding failed (if this fails, the test has been setup incorrectly)
           isNothing decodedAttachments `shouldBe` True
           theLink.joinedChannelId `shouldBe` channelId
           theLink.messageTs `shouldBe` msg.ts


### PR DESCRIPTION
supporting attachments that can't be decoded via a new version of slack-web. the biggest motivation here is to support slacklinker notifications for external bots (e.g. if a github pr has a slack link, the github notification in slack can be slacklinked to the post in the issue) 