### PR TITLE
DUX-3809: deal with linear refresh tokens

### DIFF
--- a/config/modelsFiles/models.persistentmodels
+++ b/config/modelsFiles/models.persistentmodels
@@ -177,9 +177,9 @@ LinearAPIAuthSession sql=linear_api_auth_sessions
   -- | Linear bearer token
   token LinearBearerToken
   -- | When the token expires.
-  -- FIXME(jadel): hm, these have no real refresh flow. But they also expire in
-  -- 10 years as of this writing (2025-03-03). Shrug!
   expiresAt UTCTime Maybe
+  -- | Refresh token for when the main token expires
+  refreshToken LinearRefreshToken Maybe
   -- FIXME(jadel): keep track of which scopes are on the token in question
   -- Made harder by hoauth2 API design: https://github.com/freizl/hoauth2/issues/253
 

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -3,4 +3,20 @@ set -eu
 
 DB_DIR="$(dirname $0)"
 
-refinery migrate -e POSTGRES_CONNECTION_STRING -p "$DB_DIR/migrations"
+# Refinery doesn't support Unix socket paths in connection URIs, so we bridge
+# with socat to a temporary TCP port.
+# https://github.com/rust-db/refinery/issues/258
+
+# Pick a random ephemeral port
+SOCAT_PORT=$((49152 + RANDOM % 16384))
+
+socat "TCP-LISTEN:${SOCAT_PORT},fork,reuseaddr" "UNIX-CONNECT:$PGHOST/.s.PGSQL.5432" &
+SOCAT_PID=$!
+cleanup() { kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Wait for socat to be listening
+while ! nc -z localhost "$SOCAT_PORT" 2>/dev/null; do :; done
+
+POSTGRES_CONNECTION_STRING="postgres://slacklinker@localhost:${SOCAT_PORT}/slacklinker-development" \
+    refinery migrate -e POSTGRES_CONNECTION_STRING -p "$DB_DIR/migrations"

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -1,22 +1,50 @@
 #!/usr/bin/env bash
 set -eu
 
-DB_DIR="$(dirname $0)"
+DB_DIR="$(dirname "$0")"
 
-# Refinery doesn't support Unix socket paths in connection URIs, so we bridge
-# with socat to a temporary TCP port.
-# https://github.com/rust-db/refinery/issues/258
+PGPORT="${PGPORT:-5432}"
 
-# Pick a random ephemeral port
-SOCAT_PORT=$((49152 + RANDOM % 16384))
+# Extract the host from the connection string
+SOCK_HOST=$(python3 -c "
+import os
+from urllib.parse import urlparse, parse_qs
+u = urlparse(os.environ['POSTGRES_CONNECTION_STRING'])
+qs = parse_qs(u.query)
+print(qs.get('host', [''])[0])
+")
 
-socat "TCP-LISTEN:${SOCAT_PORT},fork,reuseaddr" "UNIX-CONNECT:$PGHOST/.s.PGSQL.5432" &
-SOCAT_PID=$!
-cleanup() { kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true; }
-trap cleanup EXIT
+if [[ "${SOCK_HOST}" == /* ]]; then
+    # Refinery doesn't support Unix socket paths in connection URIs, so we bridge
+    # with socat to a temporary TCP port.
+    # https://github.com/rust-db/refinery/issues/258
 
-# Wait for socat to be listening
-while ! nc -z localhost "$SOCAT_PORT" 2>/dev/null; do :; done
+    # Pick a random ephemeral port
+    SOCAT_PORT=$((49152 + RANDOM % 16384))
 
-POSTGRES_CONNECTION_STRING="postgres://slacklinker@localhost:${SOCAT_PORT}/slacklinker-development" \
-    refinery migrate -e POSTGRES_CONNECTION_STRING -p "$DB_DIR/migrations"
+    socat "TCP-LISTEN:${SOCAT_PORT},fork,reuseaddr" "UNIX-CONNECT:${SOCK_HOST}/.s.PGSQL.$PGPORT" &
+    SOCAT_PID=$!
+    cleanup() { kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true; }
+    trap cleanup EXIT
+
+    # Wait for socat to be listening
+    while ! nc -z localhost "$SOCAT_PORT" 2>/dev/null; do :; done
+
+    # Rewrite the connection string to go through socat
+    export POSTGRES_CONNECTION_STRING
+    POSTGRES_CONNECTION_STRING=$(SOCAT_PORT="$SOCAT_PORT" python3 -c "
+import os
+from urllib.parse import urlparse, urlencode, parse_qs, urlunparse
+u = urlparse(os.environ['POSTGRES_CONNECTION_STRING'])
+port = os.environ['SOCAT_PORT']
+qs = parse_qs(u.query)
+qs.pop('host', None)
+query = urlencode(qs, doseq=True)
+import getpass
+user = u.username or getpass.getuser()
+netloc = '{}@localhost:{}'.format(user, port)
+print(urlunparse((u.scheme, netloc, u.path, u.params, query, u.fragment)))
+")
+fi
+
+refinery migrate -e POSTGRES_CONNECTION_STRING -p "$DB_DIR/migrations"

--- a/db/migrations/U1773706851__add_refresh_token.sql
+++ b/db/migrations/U1773706851__add_refresh_token.sql
@@ -1,0 +1,2 @@
+alter table "linear_api_auth_sessions"
+    add column "refresh_token" varchar null;

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -13,6 +13,7 @@ let
   # to be true. So just nuke it. w/e.
   badReferences = [
     hself.hs-opentelemetry-sdk
+    hself.hs-opentelemetry-api
     hself.warp
   ];
 

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -11,7 +11,7 @@ processes:
       flush_each_line: true
       no_color: true
       no_metadata: true
-    log_location: $PC_DIR/logs/postgres.log
+    log_location: .pc/logs/postgres.log
     readiness_probe:
       exec:
         command: env -u PGUSER psql --command 'show timezone;' --dbname postgres
@@ -31,7 +31,7 @@ processes:
       flush_each_line: true
       no_color: true
       no_metadata: true
-    log_location: $PC_DIR/logs/postgres-setup.log
+    log_location: .pc/logs/postgres-setup.log
     depends_on:
       postgres:
         condition: process_healthy

--- a/src/Slacklinker/Exceptions.hs
+++ b/src/Slacklinker/Exceptions.hs
@@ -124,6 +124,14 @@ data LinearNotAuthenticated = LinearNotAuthenticated
 instance ExceptionResponse LinearNotAuthenticated where
   status _ = status400
 
+-- | Linear integration experienced a race condition
+data LinearRaced = LinearRaced
+  deriving stock (Show)
+  deriving (Exception) via DeriveServiceException LinearRaced
+
+instance ExceptionResponse LinearRaced where
+  status _ = status400
+
 newtype VerificationException = VerificationException SlackVerificationFailed
   deriving newtype (Show)
   deriving (Exception) via DeriveServiceException VerificationException

--- a/src/Slacklinker/Linear/AppHome.hs
+++ b/src/Slacklinker/Linear/AppHome.hs
@@ -7,6 +7,7 @@ import Database.Persist qualified as P
 import Slacklinker.App (App (..), AppConfig (..), HasApp (..), runDB)
 import Slacklinker.Exceptions (SlacklinkerBug (..))
 import Slacklinker.Import
+import Slacklinker.Linear.DB (linearAuthSessionForWorkspace)
 import Slacklinker.Linear.OAuth qualified as Linear
 import Slacklinker.Models (LinearOrganization (..), Unique (..), WorkspaceId)
 import URI.ByteString (serializeURIRef')
@@ -55,9 +56,14 @@ getLinearLinkState workspaceId = do
   case bitsMay of
     Nothing -> pure LinearUnavailable
     Just (host, creds) -> do
-      mLinearOrg <- runDB . P.getBy $ UniqueOneLinearOrganizationPerTenant workspaceId
-      case entityVal <$> mLinearOrg of
-        Just org -> pure $ LinearLinked org.displayName org.urlKey
+      -- Check for both org *and* auth session; if the session was deleted
+      -- (e.g. during a reset), we want to show the re-link button.
+      mLinearOrg <- runDB do
+        org <- P.getBy $ UniqueOneLinearOrganizationPerTenant workspaceId
+        session <- linearAuthSessionForWorkspace workspaceId
+        pure $ (,) <$> (entityVal <$> org) <*> session
+      case mLinearOrg of
+        Just (org, _) -> pure $ LinearLinked org.displayName org.urlKey
         Nothing -> do
           authUri <- Linear.makeAuthorizationURI host workspaceId creds
           LinearUnlinked

--- a/src/Slacklinker/Linear/DB.hs
+++ b/src/Slacklinker/Linear/DB.hs
@@ -1,4 +1,4 @@
-module Slacklinker.Linear.DB (linearAuthSessions, linearAuthSessionForWorkspace, lockLinearAuthSession, knownLinearTeamUrlKeys) where
+module Slacklinker.Linear.DB (linearAuthSessions, linearAuthSessionForWorkspace, linearAuthSessionsWithoutRefreshToken, lockLinearAuthSession, knownLinearTeamUrlKeys) where
 
 import Database.Esqueleto.Experimental
 import Database.Esqueleto.PostgreSQL (forNoKeyUpdateOf)
@@ -21,6 +21,16 @@ linearAuthSessions = do
       `innerJoin` (table @LinearAPIAuthSession)
         `on` (\(linearOrg :& session) -> linearOrg.id ==. session.linearOrganizationId)
   pure (linearOrg, session)
+
+-- | Sessions that don't have a refresh token yet (i.e. old long-lived tokens)
+linearAuthSessionsWithoutRefreshToken ::
+  (MonadIO m) =>
+  SqlPersistT m [(Value LinearOrganizationId, Entity LinearAPIAuthSession)]
+linearAuthSessionsWithoutRefreshToken = do
+  select do
+    (linearOrg, session) <- linearAuthSessions
+    where_ $ isNothing_ session.refreshToken
+    pure (linearOrg.id, session)
 
 -- | Gets a Linear token for the given workspace
 linearAuthSessionForWorkspace ::

--- a/src/Slacklinker/Linear/DB.hs
+++ b/src/Slacklinker/Linear/DB.hs
@@ -1,9 +1,11 @@
-module Slacklinker.Linear.DB where
+module Slacklinker.Linear.DB (linearAuthSessions, linearAuthSessionForWorkspace, lockLinearAuthSession, knownLinearTeamUrlKeys) where
 
 import Database.Esqueleto.Experimental
-import Slacklinker.Linear.Types (LinearBearerToken)
+import Database.Esqueleto.PostgreSQL (forNoKeyUpdateOf)
+import Database.Esqueleto.PostgreSQL qualified as DB
 import Slacklinker.Models (
   LinearAPIAuthSession (..),
+  LinearAPIAuthSessionId,
   LinearOrganization (..),
   LinearOrganizationId,
   LinearTeam (..),
@@ -24,12 +26,23 @@ linearAuthSessions = do
 linearAuthSessionForWorkspace ::
   (MonadIO m) =>
   WorkspaceId ->
-  SqlPersistT m (Maybe (Value LinearOrganizationId, Value LinearBearerToken))
+  SqlPersistT m (Maybe (Value LinearOrganizationId, Entity LinearAPIAuthSession))
 linearAuthSessionForWorkspace wsId = do
   selectOne do
     (linearOrg, session) <- linearAuthSessions
     where_ $ linearOrg.workspaceId ==. val wsId
-    pure (linearOrg.id, session.token)
+    pure (linearOrg.id, session)
+
+{- | Takes a lock on the Linear auth session to prevent concurrent updating of
+auth sessions.
+-}
+lockLinearAuthSession :: (MonadIO m) => LinearAPIAuthSessionId -> SqlPersistT m ()
+lockLinearAuthSession id = do
+  void $ selectOne do
+    it <- from $ table @LinearAPIAuthSession
+    forNoKeyUpdateOf it DB.wait
+    where_ $ it.id ==. val id
+    pure ()
 
 {- | Gets the subset of the given list of Linear team URL keys (e.g. DUX, FOO,
 BAR, BAZ) which is known to Slacklinker to actually exist on Linear's side

--- a/src/Slacklinker/Linear/Handler.hs
+++ b/src/Slacklinker/Linear/Handler.hs
@@ -3,7 +3,6 @@
 module Slacklinker.Linear.Handler (Api, linearH) where
 
 import Data.ByteString.Base64.URL qualified as B64
-import Data.Time.Clock (addUTCTime, secondsToNominalDiffTime)
 import Database.Persist qualified as P
 import Network.OAuth.OAuth2 (AccessToken (..), OAuth2Token (..))
 import Servant.API (Get, PlainText, QueryParam', Required, (:>))
@@ -12,8 +11,9 @@ import Slacklinker.Exceptions (BadBase64 (..), BadNonce (..), LinearDisabled (..
 import Slacklinker.Import (orThrow)
 import Slacklinker.Linear.OAuth (exchangeCodeForToken, getNonceWorkspaceAndInvalidate)
 import Slacklinker.Linear.Organization (LinearOrganizationMetadata (..), linearOrganizationMetadata)
+import Slacklinker.Linear.Session (updateAuthSession)
 import Slacklinker.Linear.Types (LinearBearerToken (..))
-import Slacklinker.Models (EntityField (..), LinearAPIAuthSession (..), LinearOrganization (..), Unique (..))
+import Slacklinker.Models (EntityField (..), LinearOrganization (..), Unique (..))
 import Slacklinker.Prelude
 
 type Api =
@@ -36,24 +36,15 @@ getOauthRedirectR code state = do
   now <- liftIO getCurrentTime
 
   tokenResponse <- exchangeCodeForToken httpHost workspaceId linearCreds manager code
-  let expiresAt = (`addUTCTime` now) . secondsToNominalDiffTime . fromIntegral <$> tokenResponse.expiresIn
-      token = LinearBearerToken tokenResponse.accessToken.atoken
+  orgMeta <- linearOrganizationMetadata (LinearBearerToken tokenResponse.accessToken.atoken)
 
-  orgMeta <- linearOrganizationMetadata token
-
-  Entity linearOrgId _ <-
-    runDB
-      $ P.upsertBy
+  runDB do
+    Entity linearOrgId _ <-
+      P.upsertBy
         (UniqueLinearOrganization workspaceId orgMeta.id)
         (LinearOrganization {workspaceId = workspaceId, linearId = orgMeta.id, urlKey = orgMeta.urlKey, displayName = orgMeta.name})
         [LinearOrganizationUrlKey P.=. orgMeta.urlKey, LinearOrganizationDisplayName P.=. orgMeta.name]
-
-  void
-    . runDB
-    $ P.upsertBy
-      (UniqueLinearAPIAuthSession linearOrgId)
-      (LinearAPIAuthSession {linearOrganizationId = linearOrgId, token, expiresAt})
-      [LinearAPIAuthSessionToken P.=. token, LinearAPIAuthSessionExpiresAt P.=. expiresAt]
+    updateAuthSession now linearOrgId tokenResponse
 
   pure "Authorized!"
 

--- a/src/Slacklinker/Linear/OAuth.hs
+++ b/src/Slacklinker/Linear/OAuth.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 -- | Implements authentication setup for Linear for a workspace.
-module Slacklinker.Linear.OAuth (makeAuthorizationURI, getNonceWorkspaceAndInvalidate, exchangeCodeForToken) where
+module Slacklinker.Linear.OAuth (makeAuthorizationURI, getNonceWorkspaceAndInvalidate, exchangeCodeForToken, refreshSession) where
 
 import Control.Monad.Trans.Except (runExceptT)
 import Crypto.Random.Entropy (getEntropy)
@@ -12,11 +12,11 @@ import Data.Set qualified as Set
 import Data.Time (addUTCTime, secondsToNominalDiffTime)
 import Database.Persist qualified as P
 import Network.HTTP.Client (Manager)
-import Network.OAuth.OAuth2 (ExchangeToken (..), OAuth2Token)
+import Network.OAuth.OAuth2 (ExchangeToken (..), OAuth2Token, RefreshToken (..))
 import Network.OAuth2.Experiment qualified as HOAuth2
 import Slacklinker.App (HasApp (..), runDB)
 import Slacklinker.Exceptions (LinearOAuth2Error (..))
-import Slacklinker.Linear.Types (LinearClientId (..), LinearClientSecret (..), LinearCreds (..))
+import Slacklinker.Linear.Types (LinearClientId (..), LinearClientSecret (..), LinearCreds (..), LinearRefreshToken (..))
 import Slacklinker.Models (EntityField (..), LinearNonce (..), Unique (..), WorkspaceId)
 import Slacklinker.Prelude
 import URI.ByteString (Absolute, Authority (..), Host (..), Scheme (..), URIRef (..))
@@ -136,3 +136,11 @@ exchangeCodeForToken httpHost workspaceId creds manager code = do
 makeAuthorizationURI :: (HasApp m, MonadIO m) => Text -> WorkspaceId -> LinearCreds -> m (URIRef Absolute)
 makeAuthorizationURI httpHost workspaceId creds =
   HOAuth2.mkAuthorizationRequest . HOAuth2.IdpApplication linearIdP <$> makeAuthorizationCodeApp httpHost workspaceId creds
+
+-- | Uses the refresh token to get a new session.
+refreshSession :: (HasApp m, MonadIO m) => Text -> WorkspaceId -> LinearCreds -> Manager -> LinearRefreshToken -> m OAuth2Token
+refreshSession httpHost workspaceId creds manager token = do
+  logInfo $ "Refresh Linear API session for workspace" <> tshow workspaceId
+  idpApp <- HOAuth2.IdpApplication linearIdP <$> makeAuthorizationCodeApp httpHost workspaceId creds
+  resp <- runExceptT $ HOAuth2.conduitRefreshTokenRequest idpApp manager (RefreshToken token.unLinearRefreshToken)
+  fromEither . mapLeft (LinearOAuth2Error . tshow) $ resp

--- a/src/Slacklinker/Linear/Sender.hs
+++ b/src/Slacklinker/Linear/Sender.hs
@@ -7,14 +7,13 @@ import Data.GraphQL (get, getErrors)
 import Data.GraphQL.Error (GraphQLError (..))
 import Data.GraphQL.Monad (MonadGraphQLQuery (..))
 import Data.GraphQL.Result (getResult)
-import Database.Esqueleto.Experimental (Value (..))
 import Database.Persist qualified as P
 import Slacklinker.App (HasApp, runDB)
-import Slacklinker.Exceptions (LinearNotAuthenticated (..), SlacklinkerBug (..))
+import Slacklinker.Exceptions (SlacklinkerBug (..))
 import Slacklinker.Import
-import Slacklinker.Linear.DB (linearAuthSessionForWorkspace)
 import Slacklinker.Linear.GraphQL (runLinearGraphQL)
 import Slacklinker.Linear.GraphQL.API (LinkSlackMutation (..))
+import Slacklinker.Linear.Session (getToken)
 import Slacklinker.Linear.Types (LinearTicketId, linearTicketIdToText)
 import Slacklinker.Models (JoinedChannelId, KnownUserId, LinkedLinearTicket (..))
 import Slacklinker.Sender.Internal (runSlackEither)
@@ -79,7 +78,7 @@ instance Semigroup LinkResult where
   Duplicate <> Duplicate = Duplicate
 
 doBacklinkLinearTickets ::
-  (MonadIO m, HasApp m) =>
+  (MonadUnliftIO m, HasApp m) =>
   WorkspaceMeta ->
   SlackUrlParts ->
   JoinedChannelId ->
@@ -89,7 +88,7 @@ doBacklinkLinearTickets ::
 doBacklinkLinearTickets workspaceInfo slackUrlParts joinedChannelId knownUserId tickets = do
   -- The tickets have known linear teams, so we just have to link them.
   slackUrl <- buildSlackUrl slackUrlParts `orThrow` SlacklinkerBug "slack url not successfully reconstituted from a parsed one?!"
-  (Value linearOrgId, Value token) <- runDB $ linearAuthSessionForWorkspace workspaceInfo.workspaceId >>= (`orThrow` LinearNotAuthenticated)
+  (linearOrgId, token) <- getToken workspaceInfo.workspaceId
 
   linkingResults <- for tickets \ticket -> do
     -- This can fail (e.g. unknown ticket) and it is okay.

--- a/src/Slacklinker/Linear/Session.hs
+++ b/src/Slacklinker/Linear/Session.hs
@@ -1,18 +1,22 @@
 -- | Getting a usable auth token from Linear.
 module Slacklinker.Linear.Session where
 
+import Data.Aeson qualified as A
 import Data.Time.Clock (addUTCTime, secondsToNominalDiffTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Database.Esqueleto.Experimental (Value (..))
 import Database.Persist qualified as P
+import Network.HTTP.Client (Manager, Request (..), RequestBody (..), Response (..), httpLbs, parseRequest_)
+import Network.HTTP.Types (hContentType)
 import Network.OAuth.OAuth2 (AccessToken (..), OAuth2Token (..), RefreshToken (..))
 import Slacklinker.App (App (..), AppConfig (..), HasApp (..), runDB)
 import Slacklinker.Exceptions (LinearDisabled (..), LinearNotAuthenticated (..), LinearRaced (..))
 import Slacklinker.Import
 import Slacklinker.Linear.DB (linearAuthSessionForWorkspace, lockLinearAuthSession)
 import Slacklinker.Linear.OAuth (refreshSession)
-import Slacklinker.Linear.Types (LinearBearerToken (..), LinearRefreshToken (..))
+import Slacklinker.Linear.Types (LinearBearerToken (..), LinearClientId (..), LinearClientSecret (..), LinearCreds (..), LinearRefreshToken (..))
 import Slacklinker.Models (EntityField (..), LinearAPIAuthSession (..), LinearOrganizationId, Unique (..), WorkspaceId)
+import Web.FormUrlEncoded (Form (..), urlEncodeFormStable)
 
 {- | Updates the authentication session for a given Linear org with a new
 access/refresh token pair from a token request.
@@ -80,3 +84,24 @@ getToken' refresher workspaceId = do
 -- | Get a fresh token without using a stub.
 getToken :: (MonadUnliftIO m, HasApp m) => WorkspaceId -> m (LinearOrganizationId, LinearBearerToken)
 getToken = getToken' realRefreshToken
+
+{- | Migrate an old long-lived Linear access token to a new short-lived token
+with a refresh token, using Linear's temporary migration endpoint.
+-}
+migrateOldToken :: Manager -> LinearCreds -> LinearBearerToken -> IO OAuth2Token
+migrateOldToken manager creds (LinearBearerToken token) = do
+  let body =
+        urlEncodeFormStable
+          $ Form
+          $ mapFromList
+            [ ("access_token", [token])
+            , ("client_id", [creds.linearClientId.unLinearClientId])
+            , ("client_secret", [creds.linearClientSecret.unLinearClientSecret])
+            ]
+      req =
+        (parseRequest_ "POST https://api.linear.app/oauth/migrate_old_token")
+          { requestHeaders = [(hContentType, "application/x-www-form-urlencoded")]
+          , requestBody = RequestBodyLBS body
+          }
+  resp <- httpLbs req manager
+  fromEither . mapLeft AesonDecodeError . A.eitherDecode $ responseBody resp

--- a/src/Slacklinker/Linear/Session.hs
+++ b/src/Slacklinker/Linear/Session.hs
@@ -1,0 +1,82 @@
+-- | Getting a usable auth token from Linear.
+module Slacklinker.Linear.Session where
+
+import Data.Time.Clock (addUTCTime, secondsToNominalDiffTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Database.Esqueleto.Experimental (Value (..))
+import Database.Persist qualified as P
+import Network.OAuth.OAuth2 (AccessToken (..), OAuth2Token (..), RefreshToken (..))
+import Slacklinker.App (App (..), AppConfig (..), HasApp (..), runDB)
+import Slacklinker.Exceptions (LinearDisabled (..), LinearNotAuthenticated (..), LinearRaced (..))
+import Slacklinker.Import
+import Slacklinker.Linear.DB (linearAuthSessionForWorkspace, lockLinearAuthSession)
+import Slacklinker.Linear.OAuth (refreshSession)
+import Slacklinker.Linear.Types (LinearBearerToken (..), LinearRefreshToken (..))
+import Slacklinker.Models (EntityField (..), LinearAPIAuthSession (..), LinearOrganizationId, Unique (..), WorkspaceId)
+
+{- | Updates the authentication session for a given Linear org with a new
+access/refresh token pair from a token request.
+-}
+updateAuthSession :: (MonadIO m) => UTCTime -> LinearOrganizationId -> OAuth2Token -> SqlPersistT m ()
+updateAuthSession now linearOrgId tokenResponse = do
+  let expiresAt = (`addUTCTime` now) . secondsToNominalDiffTime . fromIntegral <$> tokenResponse.expiresIn
+      token = LinearBearerToken tokenResponse.accessToken.atoken
+      refreshToken = LinearRefreshToken . (.rtoken) <$> tokenResponse.refreshToken
+
+  void
+    $ P.upsertBy
+      (UniqueLinearAPIAuthSession linearOrgId)
+      (LinearAPIAuthSession {linearOrganizationId = linearOrgId, token, expiresAt, refreshToken})
+      [LinearAPIAuthSessionToken P.=. token, LinearAPIAuthSessionExpiresAt P.=. expiresAt, LinearAPIAuthSessionRefreshToken P.=. refreshToken]
+
+realRefreshToken :: (MonadIO m, HasApp m) => WorkspaceId -> LinearRefreshToken -> m OAuth2Token
+realRefreshToken workspaceId refreshToken = do
+  mgr <- getsApp (.manager)
+  httpHost <- getsApp (.config.slacklinkerHost) >>= (`orThrow` LinearDisabled)
+  linearCreds <- getsApp (.config.linearCreds) >>= (`orThrow` LinearDisabled)
+  refreshSession httpHost workspaceId linearCreds mgr refreshToken
+
+{- | Gets a (possibly-new) token for Linear.
+
+We do sorta evil stuff with DB locking and "http in transaction" to avoid
+races (since refresh tokens cannot be reused).
+-}
+getToken' ::
+  (MonadUnliftIO m, HasApp m) =>
+  (WorkspaceId -> LinearRefreshToken -> m OAuth2Token) ->
+  WorkspaceId ->
+  m (LinearOrganizationId, LinearBearerToken)
+getToken' refresher workspaceId = do
+  withRunInIO \runInIO -> runInIO $ runDB do
+    (_, Entity sessionId_ _) <-
+      linearAuthSessionForWorkspace workspaceId
+        >>= (`orThrow` LinearNotAuthenticated)
+    lockLinearAuthSession sessionId_
+
+    -- Once we lock the row, we have to re-fetch it to make sure we definitely
+    -- got the copy from the last time it was unlocked.
+    (Value linearOrgId, Entity sessionId session) <-
+      linearAuthSessionForWorkspace workspaceId
+        >>= (`orThrow` LinearNotAuthenticated)
+
+    unless (sessionId_ == sessionId) $ throwIO LinearRaced
+
+    now <- liftIO getCurrentTime
+    let expiry = fromMaybe (posixSecondsToUTCTime 0) session.expiresAt
+    if (now > (-thirtyMinutes) `addUTCTime` expiry)
+      then do
+        -- The failure case here is actually impossible: old Linear sessions have
+        -- 10y in the future expiry.
+        refreshToken <- session.refreshToken `orThrow` LinearNotAuthenticated
+        newToken <- liftIO $ runInIO $ refresher workspaceId refreshToken
+        updateAuthSession now linearOrgId newToken
+
+        pure (linearOrgId, LinearBearerToken newToken.accessToken.atoken)
+      else pure (linearOrgId, session.token)
+  where
+    -- Arbitrarily chosen threshold: session tokens live for 24h.
+    thirtyMinutes = secondsToNominalDiffTime $ 30 * 60
+
+-- | Get a fresh token without using a stub.
+getToken :: (MonadUnliftIO m, HasApp m) => WorkspaceId -> m (LinearOrganizationId, LinearBearerToken)
+getToken = getToken' realRefreshToken

--- a/src/Slacklinker/Linear/Teams.hs
+++ b/src/Slacklinker/Linear/Teams.hs
@@ -11,11 +11,10 @@ import Database.Esqueleto.Experimental (Value (..))
 import Database.Esqueleto.Experimental qualified as E
 import Database.Persist qualified as P
 import Slacklinker.App (HasApp, runDB)
-import Slacklinker.Exceptions (LinearNotAuthenticated (..))
-import Slacklinker.Import (orThrow)
-import Slacklinker.Linear.DB (linearAuthSessionForWorkspace, linearAuthSessions)
+import Slacklinker.Linear.DB (linearAuthSessions)
 import Slacklinker.Linear.GraphQL (PageInfo (..), paginateQuery, runLinearGraphQL, runQueryThrow)
 import Slacklinker.Linear.GraphQL.API (ListTeamsQuery (..))
+import Slacklinker.Linear.Session (getToken)
 import Slacklinker.Models
 import Slacklinker.Prelude
 
@@ -25,10 +24,9 @@ data LinearTeamAPI = LinearTeamAPI
   }
   deriving stock (Show)
 
-getLinearTeamsUncached :: (HasApp m, MonadIO m) => WorkspaceId -> m (LinearOrganizationId, Vector LinearTeamAPI)
+getLinearTeamsUncached :: (MonadUnliftIO m, HasApp m) => WorkspaceId -> m (LinearOrganizationId, Vector LinearTeamAPI)
 getLinearTeamsUncached workspaceId = do
-  session_ <- runDB $ linearAuthSessionForWorkspace workspaceId
-  (Value linearOrgId, Value token) <- session_ `orThrow` LinearNotAuthenticated
+  (linearOrgId, token) <- getToken workspaceId
 
   (linearOrgId,) <$> run token
   where
@@ -46,14 +44,14 @@ getLinearTeamsUncached workspaceId = do
             $ [get| res.teams.nodes |]
       pure (extractPageInfo [get| res.teams.pageInfo |], thisResult)
 
-updateLinearTeamsCache :: (HasApp m, MonadIO m) => WorkspaceId -> m ()
+updateLinearTeamsCache :: (MonadUnliftIO m, HasApp m) => WorkspaceId -> m ()
 updateLinearTeamsCache workspaceId = do
   (linearOrgId, teams) <- getLinearTeamsUncached workspaceId
   -- FIXME(jadel): delete obsolete linear teams
   runDB do
     for_ teams \team -> P.insertBy LinearTeam {linearOrganizationId = linearOrgId, urlKey = team.urlKey}
 
-updateAllLinearTeamsCaches :: (HasApp m, MonadIO m) => m ()
+updateAllLinearTeamsCaches :: (MonadUnliftIO m, HasApp m) => m ()
 updateAllLinearTeamsCaches = do
   orgs <- fmap (fmap unValue) . runDB $ E.select do
     (linearOrg, _session) <- linearAuthSessions

--- a/src/Slacklinker/Linear/Types.hs
+++ b/src/Slacklinker/Linear/Types.hs
@@ -4,6 +4,7 @@ module Slacklinker.Linear.Types (
   LinearClientSecret (..),
   LinearCreds (..),
   LinearBearerToken (..),
+  LinearRefreshToken (..),
   LinearTicketUUID (..),
   LinearTicketId (..),
   linearTicketIdToText,
@@ -31,10 +32,17 @@ data LinearCreds = LinearCreds
 
 -- | Bearer token for the Linear API. This belongs to one Slacklinker tenant.
 newtype LinearBearerToken = LinearBearerToken {unLinearBearerToken :: Text}
-  deriving newtype (PersistField, PersistFieldSql)
+  deriving newtype (Eq, PersistField, PersistFieldSql)
 
 instance Show LinearBearerToken where
   show _ = "LinearBearerToken REDACTED"
+
+-- | Bearer token for the Linear API. This belongs to one Slacklinker tenant.
+newtype LinearRefreshToken = LinearRefreshToken {unLinearRefreshToken :: Text}
+  deriving newtype (PersistField, PersistFieldSql)
+
+instance Show LinearRefreshToken where
+  show _ = "LinearRefreshToken REDACTED"
 
 -- | Linear-side ticket UUID
 newtype LinearTicketUUID = LinearTicketUUID {unLinearTicketId :: UUID}

--- a/src/Slacklinker/Slack/OAuth.hs
+++ b/src/Slacklinker/Slack/OAuth.hs
@@ -8,8 +8,7 @@ import Servant.API
 import Servant.Client (ClientM, client)
 import Slacklinker.Import
 import Slacklinker.Types (SlackClientSecret (..), SlackToken)
-import Web.FormUrlEncoded (ToForm, genericToForm)
-import Web.Internal.FormUrlEncoded (ToForm (..))
+import Web.FormUrlEncoded (ToForm (..), genericToForm)
 import Web.Slack.Common (TeamId (..))
 import Web.Slack.Internal
 import Web.Slack.Pager (Response)

--- a/src/Slacklinker/Task.hs
+++ b/src/Slacklinker/Task.hs
@@ -4,12 +4,18 @@
 
 module Slacklinker.Task where
 
-import Data.Aeson (Value, camelTo2)
+import Data.Aeson (camelTo2)
+import Data.Aeson qualified as A
+import Database.Esqueleto.Experimental (Value (..))
 import Options.Generic
-import Slacklinker.App (App (..), AppM, appShutdownNoSender, appStartupNoSender, makeApp, runAppM, runDB)
+import Slacklinker.App (App (..), AppConfig (..), AppM, HasApp (..), appShutdownNoSender, appStartupNoSender, makeApp, runAppM, runDB)
+import Slacklinker.Exceptions (LinearDisabled (..))
 import Slacklinker.Import
+import Slacklinker.Linear.DB (linearAuthSessionsWithoutRefreshToken)
+import Slacklinker.Linear.Session (migrateOldToken, updateAuthSession)
 import Slacklinker.Linear.Teams (updateAllLinearTeamsCaches)
 import Slacklinker.Migrate.SuggestMigrations (suggestMigrations)
+import Slacklinker.Models (LinearAPIAuthSession (..))
 import Slacklinker.Settings
 
 instance ParseFields SlacklinkerSettingTag
@@ -30,6 +36,7 @@ data Task w
       , value :: w ::: ByteString
       }
   | UpdateAllLinearTeams
+  | MigrateLinearTokens
   deriving stock (Generic)
 
 kebabCaseModifier :: Modifiers
@@ -49,7 +56,7 @@ taskMain = do
 doSetSetting ::
   (MonadIO m) =>
   SlacklinkerSettingTag ->
-  Value ->
+  A.Value ->
   SqlPersistT m ()
 doSetSetting settingName value = do
   setting <- fromEither . mapLeft AesonDecodeError $ unmarshalSettingByTag settingName value
@@ -59,3 +66,13 @@ runTask :: Task Unwrapped -> AppM ()
 runTask (SuggestMigrations name dontFormat) = runDB $ suggestMigrations name dontFormat
 runTask (SetSetting settingName value) = runDB $ doSetSetting settingName =<< decodeThrow value
 runTask UpdateAllLinearTeams = updateAllLinearTeamsCaches
+runTask MigrateLinearTokens = do
+  linearCreds <- getsApp (.config.linearCreds) >>= (`orThrow` LinearDisabled)
+  manager <- getsApp (.manager)
+  sessions <- runDB linearAuthSessionsWithoutRefreshToken
+  for_ sessions \(Value linearOrgId, Entity _ session) -> do
+    logInfo $ "Migrating token for org " <> tshow linearOrgId
+    tokenResponse <- liftIO $ migrateOldToken manager linearCreds session.token
+    now <- liftIO getCurrentTime
+    runDB $ updateAuthSession now linearOrgId tokenResponse
+    logInfo $ "Migrated token for org " <> tshow linearOrgId

--- a/test/Slacklinker/Linear/SessionSpec.hs
+++ b/test/Slacklinker/Linear/SessionSpec.hs
@@ -1,0 +1,100 @@
+module Slacklinker.Linear.SessionSpec (spec) where
+
+import Data.Time.Clock (addUTCTime, secondsToNominalDiffTime)
+import Database.Persist (insert, insert_)
+import Network.OAuth.OAuth2 (AccessToken (..), OAuth2Token (..), RefreshToken (..))
+import Slacklinker.App (runAppM, runDB)
+import Slacklinker.Exceptions (LinearNotAuthenticated (..))
+import Slacklinker.Linear.Session (getToken')
+import Slacklinker.Linear.Types (LinearBearerToken (..), LinearRefreshToken (..))
+import Slacklinker.Models
+import TestApp (withApp)
+import TestImport
+import TestUtils (createWorkspace)
+
+setupLinearSession :: (MonadIO m) => WorkspaceId -> Maybe UTCTime -> Maybe LinearRefreshToken -> Text -> SqlPersistT m ()
+setupLinearSession wsId expiresAt refreshToken token = do
+  orgId <-
+    insert
+      LinearOrganization
+        { workspaceId = wsId
+        , linearId = "org-123"
+        , urlKey = "testorg"
+        , displayName = "Test Org"
+        }
+  insert_
+    LinearAPIAuthSession
+      { linearOrganizationId = orgId
+      , token = LinearBearerToken token
+      , expiresAt
+      , refreshToken
+      }
+
+cannedOAuth2Token :: OAuth2Token
+cannedOAuth2Token =
+  OAuth2Token
+    { accessToken = AccessToken "new-access-token"
+    , refreshToken = Just (RefreshToken "new-refresh-token")
+    , expiresIn = Just 86400
+    , tokenType = Nothing
+    , idToken = Nothing
+    , scope = Nothing
+    , rawResponse = error "not used"
+    }
+
+spec :: Spec
+spec = do
+  withApp $ describe "getToken'" do
+    it "returns existing token when not expired" \app -> runAppM app do
+      (wsId, _) <- createWorkspace
+      now <- liftIO getCurrentTime
+      let futureExpiry = addUTCTime (secondsToNominalDiffTime 3600) now
+      runDB $ setupLinearSession wsId (Just futureExpiry) (Just $ LinearRefreshToken "refresh") "existing-token"
+
+      refresherCalled <- liftIO $ newIORef False
+      let fakeRefresher _ _ = do
+            liftIO $ writeIORef refresherCalled True
+            pure cannedOAuth2Token
+
+      (_, result) <- getToken' fakeRefresher wsId
+      liftIO do
+        result `shouldBe` LinearBearerToken "existing-token"
+        readIORef refresherCalled >>= (`shouldBe` False)
+
+    it "refreshes when token is near expiry" \app -> runAppM app do
+      (wsId, _) <- createWorkspace
+      now <- liftIO getCurrentTime
+      -- 10 minutes from now — within the 30-minute refresh threshold
+      let nearExpiry = addUTCTime (secondsToNominalDiffTime 600) now
+      runDB $ setupLinearSession wsId (Just nearExpiry) (Just $ LinearRefreshToken "old-refresh") "old-token"
+
+      refresherCalled <- liftIO $ newIORef False
+      let fakeRefresher _ _ = do
+            liftIO $ writeIORef refresherCalled True
+            pure cannedOAuth2Token
+
+      (_, result) <- getToken' fakeRefresher wsId
+      liftIO do
+        result `shouldBe` LinearBearerToken "new-access-token"
+        readIORef refresherCalled >>= (`shouldBe` True)
+
+    it "throws when expired and no refresh token" \app -> runAppM app do
+      (wsId, _) <- createWorkspace
+      now <- liftIO getCurrentTime
+      let pastExpiry = addUTCTime (secondsToNominalDiffTime (-3600)) now
+      runDB $ setupLinearSession wsId (Just pastExpiry) Nothing "old-token"
+
+      let fakeRefresher _ _ = pure cannedOAuth2Token
+
+      withRunInIO \runInIO ->
+        runInIO (getToken' fakeRefresher wsId)
+          `shouldThrow` (\LinearNotAuthenticated -> True)
+
+    it "throws when no session exists" \app -> runAppM app do
+      (wsId, _) <- createWorkspace
+
+      let fakeRefresher _ _ = pure cannedOAuth2Token
+
+      withRunInIO \runInIO ->
+        runInIO (getToken' fakeRefresher wsId)
+          `shouldThrow` (\LinearNotAuthenticated -> True)


### PR DESCRIPTION
I have tested this locally through both the one-off-task flow and the initial setup flow. Seems to work!

Prod deployment plan:
Merge, send PR to infra repo.
Get someone with required admin perms to set this in the Linear API settings:
<img width="683" height="456" alt="image" src="https://github.com/user-attachments/assets/af010a72-9deb-4e4b-8a1e-f797b66c03b9" />
Run the one-off-task in prod.
Verify that linear tickets still link properly.
Verify that linear tickets *still* link properly in 24h.

Delete one-off-task after april 1 since nobody can have this problem anymore due to Linear sunsetting the legacy tokens.