### PR TITLE
Disable sketchy DB proxying in production

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -30,4 +30,7 @@ if [[ ! -v $DONT_PROCESS_COMPOSE ]]; then
     # Host part needs to be urlencoded (or at least the slashes do...)
     export DATABASE_URL="postgres:///slacklinker-development?host=$PGHOST"
     export POSTGRES_CONNECTION_STRING="$DATABASE_URL"
+
+    # Used to enable silly proxying of Unix database sockets for development
+    export SLACKLINKER_DEVELOPMENT=1
 fi

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -5,8 +5,10 @@ DB_DIR="$(dirname "$0")"
 
 PGPORT="${PGPORT:-5432}"
 
-# Extract the host from the connection string
-SOCK_HOST=$(python3 -c "
+# This is super sketchy and we should only do it in dev
+if [[ -v SLACKLINKER_DEVELOPMENT ]]; then
+    # Extract the host from the connection string
+    SOCK_HOST=$(python3 -c "
 import os
 from urllib.parse import urlparse, parse_qs
 u = urlparse(os.environ['POSTGRES_CONNECTION_STRING'])
@@ -14,25 +16,25 @@ qs = parse_qs(u.query)
 print(qs.get('host', [''])[0])
 ")
 
-if [[ "${SOCK_HOST}" == /* ]]; then
-    # Refinery doesn't support Unix socket paths in connection URIs, so we bridge
-    # with socat to a temporary TCP port.
-    # https://github.com/rust-db/refinery/issues/258
+    if [[ "${SOCK_HOST}" == /* ]]; then
+        # Refinery doesn't support Unix socket paths in connection URIs, so we bridge
+        # with socat to a temporary TCP port.
+        # https://github.com/rust-db/refinery/issues/258
 
-    # Pick a random ephemeral port
-    SOCAT_PORT=$((49152 + RANDOM % 16384))
+        # Pick a random ephemeral port
+        SOCAT_PORT=$((49152 + RANDOM % 16384))
 
-    socat "TCP-LISTEN:${SOCAT_PORT},fork,reuseaddr" "UNIX-CONNECT:${SOCK_HOST}/.s.PGSQL.$PGPORT" &
-    SOCAT_PID=$!
-    cleanup() { kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true; }
-    trap cleanup EXIT
+        socat "TCP-LISTEN:${SOCAT_PORT},fork,reuseaddr" "UNIX-CONNECT:${SOCK_HOST}/.s.PGSQL.$PGPORT" &
+        SOCAT_PID=$!
+        cleanup() { kill "$SOCAT_PID" 2>/dev/null || true; wait "$SOCAT_PID" 2>/dev/null || true; }
+        trap cleanup EXIT
 
-    # Wait for socat to be listening
-    while ! nc -z localhost "$SOCAT_PORT" 2>/dev/null; do :; done
+        # Wait for socat to be listening
+        while ! nc -z localhost "$SOCAT_PORT" 2>/dev/null; do :; done
 
-    # Rewrite the connection string to go through socat
-    export POSTGRES_CONNECTION_STRING
-    POSTGRES_CONNECTION_STRING=$(SOCAT_PORT="$SOCAT_PORT" python3 -c "
+        # Rewrite the connection string to go through socat
+        export POSTGRES_CONNECTION_STRING
+        POSTGRES_CONNECTION_STRING=$(SOCAT_PORT="$SOCAT_PORT" python3 -c "
 import os
 from urllib.parse import urlparse, urlencode, parse_qs, urlunparse
 u = urlparse(os.environ['POSTGRES_CONNECTION_STRING'])
@@ -45,6 +47,7 @@ user = u.username or getpass.getuser()
 netloc = '{}@localhost:{}'.format(user, port)
 print(urlunparse((u.scheme, netloc, u.path, u.params, query, u.fragment)))
 ")
+    fi
 fi
 
 refinery migrate -e POSTGRES_CONNECTION_STRING -p "$DB_DIR/migrations"


### PR DESCRIPTION
This failed due to python3 being missing. It's true that we could fix the python3 being missing, but I don't *like* this code at all and never really intended it to be running in prod.

```
Mar 27 22:34:06 slacklinker systemd[1]: Starting slacklinker-init.service...
Mar 27 22:34:06 slacklinker migrate.sh[551252]: /nix/store/ri10q111dq2crvfw9nm646x82j0hylgl-slacklinker-0.0.0/db/.migrate.sh-wrapped: line 15: python3: command not found
Mar 27 22:34:06 slacklinker systemd[1]: slacklinker-init.service: Main process exited, code=exited, status=127/n/a
Mar 27 22:34:06 slacklinker systemd[1]: slacklinker-init.service: Failed with result 'exit-code'.
Mar 27 22:34:06 slacklinker systemd[1]: Failed to start slacklinker-init.service.
```