### PR TITLE
Support scoped Block Kit section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ Slacklinker's own app id here.
 
 - `BLOCKED_APP_IDS=appid1,appid2`
 
+Slacklinker normally extracts only structured rich-text links. Extract links
+from Block Kit section text and fields in these comma-separated channel IDs:
+
+- `SECTION_LINK_CHANNEL_IDS=C0123456789,C9876543210`
+
+This setting defaults to no channels. Keep it narrowly scoped: automated apps
+commonly use section blocks, so enabling section extraction broadly can create
+noisy or unexpected backlinks.
+
 ### Linear setup
 
 Linear integration is optional and is not visible if not configured.

--- a/src/Slacklinker/App.hs
+++ b/src/Slacklinker/App.hs
@@ -32,6 +32,7 @@ import Slacklinker.Linear.Types (LinearClientId (..), LinearClientSecret (..), L
 import Slacklinker.Types (SlackClientSecret (..), SlackToken (..))
 import System.Environment (getEnv, lookupEnv)
 import Web.Slack (SlackConfig (..))
+import Web.Slack.Conversation (ConversationId (..))
 import Web.Slack.Experimental.RequestVerification (SlackSigningSecret (..))
 
 data AppConfig = AppConfig
@@ -57,6 +58,9 @@ data AppConfig = AppConfig
   , blockedAppIds :: [Text]
   {- ^ do not backlink to posts from these apps
   used to prevent infinite loops
+  -}
+  , sectionLinkChannelIds :: [ConversationId]
+  {- ^ channels where links should also be extracted from Block Kit section blocks
   -}
   }
   deriving stock (Show)
@@ -162,6 +166,8 @@ getConfiguration = do
   logLevel <- maybe LevelInfo readLogLevel <$> lookupEnv "LOG_LEVEL"
   sqlLogLevel <- maybe LevelInfo readLogLevel <$> lookupEnv "LOG_SQL"
   blockedAppIds <- fmap (splitOn "," . decodeUtf8) (BS.pack <$> getEnv "BLOCKED_APP_IDS")
+  sectionLinkChannelIds <-
+    maybe [] (map ConversationId . splitOn "," . pack) <$> lookupEnv "SECTION_LINK_CHANNEL_IDS"
 
   pure AppConfig {..}
   where

--- a/src/Slacklinker/Handler/Webhook.hs
+++ b/src/Slacklinker/Handler/Webhook.hs
@@ -19,7 +19,7 @@ import Generics.Deriving.ConNames (conNameOf)
 import OpenTelemetry.Trace.Core (Attribute, Span, ToAttribute (toAttribute))
 import Slacklinker.App
 import Slacklinker.Exceptions
-import Slacklinker.Extract.FreeText (extractLinksFromJson)
+import Slacklinker.Extract.FreeText (extractLinksFromJson, extractUrls)
 import Slacklinker.Extract.Types
 import Slacklinker.Handler.Webhook.ImCommand (handleImCommand)
 import Slacklinker.Import
@@ -46,6 +46,13 @@ extractBlockLinks = fromBlock
 
     fromRichItem (RichItemLink RichLinkAttrs {..}) = [url]
     fromRichItem _ = []
+
+extractSectionBlockLinks :: Text -> SlackBlock -> [Text]
+extractSectionBlockLinks slackSubdomain (SlackBlockSection section) =
+  mconcat $ extractUrls slackSubdomain <$> (sectionTexts >>= unSlackTexts)
+  where
+    sectionTexts = maybeToList section.slackSectionText <> fromMaybe [] section.slackSectionFields
+extractSectionBlockLinks _ _ = []
 
 extractAttachedLinks :: DecodedMessageAttachment -> [Text]
 extractAttachedLinks attachment = fromUrlLinks ++ blockLinks
@@ -145,7 +152,12 @@ handleMessage msg teamId = do
       let blockLinks = mconcat $ extractBlockLinks <$> fromMaybe [] ev.blocks
           attachedLinks = mconcat $ extractAttachedLinks <$> mapMaybe decoded (fromMaybe [] ev.attachments)
           rawLinks = mconcat $ extractLinksFromJson workspace.slackSubdomain <$> maybe [] (map raw) ev.attachments
-          links = nub $ blockLinks <> attachedLinks <> rawLinks
+      sectionLinkChannelIds <- getsApp (.config.sectionLinkChannelIds)
+      let sectionLinks =
+            if ev.channel `elem` sectionLinkChannelIds
+              then mconcat $ extractSectionBlockLinks workspace.slackSubdomain <$> fromMaybe [] ev.blocks
+              else []
+          links = nub $ blockLinks <> attachedLinks <> rawLinks <> sectionLinks
 
       -- FIXME(evanr): The only IO these `record*` functions perform
       -- currently is database inserts, so I think they can/should be run in

--- a/test/Slacklinker/Handler/WebhookSpec.hs
+++ b/test/Slacklinker/Handler/WebhookSpec.hs
@@ -1,7 +1,7 @@
 module Slacklinker.Handler.WebhookSpec (spec) where
 
 import Database.Persist
-import Slacklinker.App (HasApp, runAppM, runDB)
+import Slacklinker.App (App (..), AppConfig (..), HasApp, runAppM, runDB)
 import Slacklinker.Handler.TestData
 import Slacklinker.Handler.TestUtils
 import Slacklinker.Handler.Webhook (handleMessage)
@@ -73,6 +73,29 @@ spec = do
           theLink.messageTs `shouldBe` msg.ts
           theLink.threadTs `shouldBe` Nothing
           theLink.sent `shouldBe` False
+
+    it "extracts a link from a section block in a configured channel" \app -> do
+      let (url, parts) = sampleUrl
+          sectionText = "> <" <> url <> ">"
+          msg = messageEventWithBlocks ts1 [SlackBlockSection . slackSectionWithText $ message sectionText]
+          scopedApp = app {config = app.config {sectionLinkChannelIds = [msg.channel]}}
+      runAppM scopedApp do
+        (wsId, teamId) <- createWorkspace
+        handleMessage msg teamId
+
+        Just _ <- runDB $ getBy $ UniqueRepliedThread wsId parts.channelId parts.messageTs
+        pure ()
+
+    it "ignores section-block links outside configured channels" \app -> do
+      runAppM app do
+        (wsId, teamId) <- createWorkspace
+        let (url, parts) = sampleUrl
+            sectionText = "> <" <> url <> ">"
+            msg = messageEventWithBlocks ts1 [SlackBlockSection . slackSectionWithText $ message sectionText]
+        handleMessage msg teamId
+
+        Nothing <- runDB $ getBy $ UniqueRepliedThread wsId parts.channelId parts.messageTs
+        pure ()
 
     it "can deal with a forwarded url" \app -> do
       runAppM app $ do

--- a/test/TestApp.hs
+++ b/test/TestApp.hs
@@ -30,6 +30,7 @@ testAppConfig postgresConnectionString =
     , sqlLogLevel = LevelInfo
     , logLevel = LevelInfo
     , blockedAppIds = []
+    , sectionLinkChannelIds = []
     , linearCreds = Nothing
     , slacklinkerHost = Nothing
     }


### PR DESCRIPTION
# Support scoped Block Kit section links

> [!WARNING]
> This change and most of the pull request description were generated by AI at the explicit request of a human. Please feel free to close if it feels unwelcome.

## Summary

- Add `SECTION_LINK_CHANNEL_IDS`, an opt-in comma-separated channel allowlist.
- Extract Slack message URLs from Block Kit section text and fields only in configured channels.
- Preserve existing structured rich-text and attachment extraction everywhere else.
- Cover configured and unconfigured channel behavior with integration tests.

## Tradeoffs and scoping

Some Slack integrations put links in Block Kit `section` blocks rather than structured `rich_text` blocks. Enabling section extraction globally would affect a large population of automated posts and could create noisy or unexpected backlinks.

Options considered:

- **Global section extraction:** simplest, but has the largest blast radius and noise risk.
- **Source-app allowlist:** narrower, but an app can post across many unrelated channels.
- **Channel allowlist:** selected because it limits behavior to explicitly opted-in workflows and can be expanded deliberately.

Existing same-thread suppression, backlink deduplication, and blocked-app handling continue to apply.

## Configuration

```text
SECTION_LINK_CHANNEL_IDS=C0123456789
```

With the variable unset, behavior is unchanged.
